### PR TITLE
Replace reading of package.json in this package with require() from readJSONFile() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
+### Others
+
+* [#50] - Replace reading of `package.json` in this package with `require()` from `readJSONFile()` function
+
 [Unreleased]: https://github.com/sounisi5011/package-version-git-tag/compare/v1.1.1...HEAD
+[#50]: https://github.com/sounisi5011/package-version-git-tag/pull/50
 
 ## [1.1.1] (2019-09-02 UTC)
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,32 +1,30 @@
 #!/usr/bin/env node
 
 import program from 'commander';
-import path from 'path';
 
 import main from './';
-import { isObject, readJSONFile } from './utils';
+import { isObject } from './utils';
 
-(async () => {
-    const PKG = await readJSONFile(path.join(__dirname, '..', 'package.json'));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const PKG: unknown = require('../package.json');
 
-    if (isObject(PKG)) {
-        if (typeof PKG.version === 'string') {
-            program.version(PKG.version, '-v, --version');
-        }
-
-        if (typeof PKG.description === 'string') {
-            program.description(PKG.description);
-        }
+if (isObject(PKG)) {
+    if (typeof PKG.version === 'string') {
+        program.version(PKG.version, '-v, --version');
     }
 
-    program
-        .option('--push', '`git push` the added tag to the remote repository')
-        .parse(process.argv);
+    if (typeof PKG.description === 'string') {
+        program.description(PKG.description);
+    }
+}
 
-    main({
-        push: program.push,
-    }).catch(error => {
-        process.exitCode = 1;
-        console.error(error instanceof Error ? error.message : error);
-    });
-})();
+program
+    .option('--push', '`git push` the added tag to the remote repository')
+    .parse(process.argv);
+
+main({
+    push: program.push,
+}).catch(error => {
+    process.exitCode = 1;
+    console.error(error instanceof Error ? error.message : error);
+});


### PR DESCRIPTION
JSON file reading can be substituted with `require()`.
Since the async/await syntax is no longer required, the contents of the generated file will be smaller.