### PR TITLE
Change TypeScript output from ES2015 to ES2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Others
 
 * [#50] - Replace reading of `package.json` in this package with `require()` from `readJSONFile()` function
+* [#51] - Change TypeScript output from ES2015 to ES2017
 
 [Unreleased]: https://github.com/sounisi5011/package-version-git-tag/compare/v1.1.1...HEAD
 [#50]: https://github.com/sounisi5011/package-version-git-tag/pull/50
+[#51]: https://github.com/sounisi5011/package-version-git-tag/pull/51
 
 ## [1.1.1] (2019-09-02 UTC)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2017",
     "types": ["node"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Node 8.3+ supports almost all the functions of ES2017.
Reference: https://node.green/#ES2017