### PR TITLE
Add annotated Git tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * [#81] - Custom tag prefix
+* [#83] - Annotated Git tag
 
 ### Supported Node version
 
@@ -27,6 +28,7 @@
 [#57]: https://github.com/sounisi5011/package-version-git-tag/pull/57
 [#80]: https://github.com/sounisi5011/package-version-git-tag/pull/80
 [#81]: https://github.com/sounisi5011/package-version-git-tag/pull/81
+[#83]: https://github.com/sounisi5011/package-version-git-tag/pull/83
 
 ## [1.2.0] (2019-11-09 UTC)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,11 @@
         }
       }
     },
+    "@improved/node": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@improved/node/-/node-1.1.1.tgz",
+      "integrity": "sha512-ePDxG9UuU9Kobk90ZUjtmDW8IT9U7aRb1/Rl9683MRNM+ur0ocHL2v7TPH2ajTiVSBUFbbeW8vKIt9jrb0JIAA=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -1321,6 +1326,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "command-join": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/command-join/-/command-join-3.0.0.tgz",
+      "integrity": "sha512-areSrJRrc9cbaA+Hxhs+QP4y+lkWXClAyOmxd79NvGEqUw1uLLaMKa2Tmuc1AkaER9XzmGTzpFWzwucYottMKw==",
+      "requires": {
+        "@improved/node": "^1.0.0"
+      }
     },
     "command-line-args": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     ]
   },
   "dependencies": {
+    "command-join": "3.0.0",
     "commander": "4.0.0"
   },
   "devDependencies": {

--- a/src/git.ts
+++ b/src/git.ts
@@ -49,25 +49,27 @@ export async function setTag(
         dryRun?: boolean;
     } = {},
 ): Promise<void> {
-    try {
-        const args = ['tag', tagName];
-        if (sign || typeof message === 'string') {
-            /**
-             * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
-             */
-            args.push(sign ? '-sm' : '-m', message || '');
-        }
-        const commandText = `git ${commandJoin(args)}`;
-        if (typeof debug === 'function') {
-            printVerbose(debug({ commandText, args }));
-        } else if (debug) {
-            printVerbose(`> ${commandText}`);
-        }
-        if (!dryRun) {
+    const args = ['tag', tagName];
+    if (sign || typeof message === 'string') {
+        /**
+         * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
+         */
+        args.push(sign ? '-sm' : '-m', message || '');
+    }
+
+    const commandText = `git ${commandJoin(args)}`;
+    if (typeof debug === 'function') {
+        printVerbose(debug({ commandText, args }));
+    } else if (debug) {
+        printVerbose(`> ${commandText}`);
+    }
+
+    if (!dryRun) {
+        try {
             await execFileAsync('git', args);
+        } catch (error) {
+            throw new Error(`setTag() Error: ${error}`);
         }
-    } catch (error) {
-        throw new Error(`setTag() Error: ${error}`);
     }
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'child_process';
+import { commandJoin } from 'command-join';
 import { promisify } from 'util';
 
 import { printVerbose } from './utils';
@@ -32,16 +33,30 @@ export async function isHeadTag(tagName: string): Promise<boolean> {
 export async function setTag(
     tagName: string,
     {
+        message,
+        sign = false,
         debug = false,
         dryRun = false,
-    }: { debug?: boolean; dryRun?: boolean } = {},
+    }: {
+        message?: string;
+        sign?: boolean;
+        debug?: boolean;
+        dryRun?: boolean;
+    } = {},
 ): Promise<void> {
     try {
+        const args = ['tag', tagName];
+        if (sign || typeof message === 'string') {
+            /**
+             * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
+             */
+            args.push(sign ? '-sm' : '-m', message || '');
+        }
         if (debug) {
-            printVerbose(`> git tag ${tagName}`);
+            printVerbose(`> git ${commandJoin(args)}`);
         }
         if (!dryRun) {
-            await execFileAsync('git', ['tag', tagName]);
+            await execFileAsync('git', args);
         }
     } catch (error) {
         throw new Error(`setTag() Error: ${error}`);
@@ -57,11 +72,12 @@ export async function push(
     }: { repository?: string; debug?: boolean; dryRun?: boolean } = {},
 ): Promise<void> {
     try {
+        const args = ['push', repository, src];
         if (debug) {
-            printVerbose(`> git push ${repository} ${src}`);
+            printVerbose(`> git ${commandJoin(args)}`);
         }
         if (!dryRun) {
-            await execFileAsync('git', ['push', repository, src]);
+            await execFileAsync('git', args);
         }
     } catch (error) {
         throw new Error(`push() Error: ${error}`);

--- a/src/git.ts
+++ b/src/git.ts
@@ -57,11 +57,13 @@ export async function setTag(
               ['tag', tagName, sign ? '-sm' : '-m', message || '']
             : ['tag', tagName];
 
-    const commandText = `git ${commandJoin(args)}`;
-    if (typeof debug === 'function') {
-        printVerbose(debug({ commandText, args }));
-    } else if (debug) {
-        printVerbose(`> ${commandText}`);
+    if (debug) {
+        const commandText = `git ${commandJoin(args)}`;
+        printVerbose(
+            typeof debug === 'function'
+                ? debug({ commandText, args })
+                : `> ${commandText}`,
+        );
     }
 
     if (!dryRun) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -59,11 +59,11 @@ export async function setTag(
                 : ['tag', tagName];
         if (debug) {
             const commandText = `git ${commandJoin(args)}`;
-            printVerbose(
-                typeof debug === 'function'
-                    ? debug({ commandText, args })
-                    : `> ${commandText}`,
-            );
+            if (typeof debug === 'function') {
+                printVerbose(debug({ commandText, args }));
+            } else {
+                printVerbose(`> ${commandText}`);
+            }
         }
         if (!dryRun) {
             await execFileAsync('git', args);

--- a/src/git.ts
+++ b/src/git.ts
@@ -57,13 +57,11 @@ export async function setTag(
               ['tag', tagName, sign ? '-sm' : '-m', message || '']
             : ['tag', tagName];
 
-    if (debug) {
-        const commandText = `git ${commandJoin(args)}`;
-        printVerbose(
-            typeof debug === 'function'
-                ? debug({ commandText, args })
-                : `> ${commandText}`,
-        );
+    const commandText = `git ${commandJoin(args)}`;
+    if (typeof debug === 'function') {
+        printVerbose(debug({ commandText, args }));
+    } else if (debug) {
+        printVerbose(`> ${commandText}`);
     }
 
     if (!dryRun) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,12 @@ export async function setTag(
     }: {
         message?: string;
         sign?: boolean;
-        debug?: boolean;
+        debug?:
+            | boolean
+            | ((arg: {
+                  commandText: string;
+                  args: ReadonlyArray<string>;
+              }) => string);
         dryRun?: boolean;
     } = {},
 ): Promise<void> {
@@ -53,7 +58,12 @@ export async function setTag(
             args.push(sign ? '-sm' : '-m', message || '');
         }
         if (debug) {
-            printVerbose(`> git ${commandJoin(args)}`);
+            const commandText = `git ${commandJoin(args)}`;
+            printVerbose(
+                typeof debug === 'function'
+                    ? debug({ commandText, args })
+                    : `> ${commandText}`,
+            );
         }
         if (!dryRun) {
             await execFileAsync('git', args);

--- a/src/git.ts
+++ b/src/git.ts
@@ -49,13 +49,13 @@ export async function setTag(
         dryRun?: boolean;
     } = {},
 ): Promise<void> {
-    const args = ['tag', tagName];
-    if (sign || typeof message === 'string') {
-        /**
-         * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
-         */
-        args.push(sign ? '-sm' : '-m', message || '');
-    }
+    const args =
+        sign || typeof message === 'string'
+            ? /**
+               * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
+               */
+              ['tag', tagName, sign ? '-sm' : '-m', message || '']
+            : ['tag', tagName];
 
     const commandText = `git ${commandJoin(args)}`;
     if (typeof debug === 'function') {

--- a/src/git.ts
+++ b/src/git.ts
@@ -57,13 +57,11 @@ export async function setTag(
                    */
                   ['tag', tagName, sign ? '-sm' : '-m', message || '']
                 : ['tag', tagName];
-        if (debug) {
-            const commandText = `git ${commandJoin(args)}`;
-            if (typeof debug === 'function') {
-                printVerbose(debug({ commandText, args }));
-            } else {
-                printVerbose(`> ${commandText}`);
-            }
+        const commandText = `git ${commandJoin(args)}`;
+        if (typeof debug === 'function') {
+            printVerbose(debug({ commandText, args }));
+        } else if (debug) {
+            printVerbose(`> ${commandText}`);
         }
         if (!dryRun) {
             await execFileAsync('git', args);

--- a/src/git.ts
+++ b/src/git.ts
@@ -30,7 +30,7 @@ export async function isHeadTag(tagName: string): Promise<boolean> {
     }
 }
 
-export function genTagCmdArgs(
+function genTagCmdArgs(
     tagName: string,
     message?: string,
     sign: boolean = false,

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,12 +40,7 @@ export async function setTag(
     }: {
         message?: string;
         sign?: boolean;
-        debug?:
-            | boolean
-            | ((arg: {
-                  commandText: string;
-                  args: ReadonlyArray<string>;
-              }) => string);
+        debug?: boolean | ((commandText: string) => string);
         dryRun?: boolean;
     } = {},
 ): Promise<void> {
@@ -59,7 +54,7 @@ export async function setTag(
 
     const commandText = `git ${commandJoin(args)}`;
     if (typeof debug === 'function') {
-        printVerbose(debug({ commandText, args }));
+        printVerbose(debug(commandText));
     } else if (debug) {
         printVerbose(`> ${commandText}`);
     }

--- a/src/git.ts
+++ b/src/git.ts
@@ -50,13 +50,13 @@ export async function setTag(
     } = {},
 ): Promise<void> {
     try {
-        const args = ['tag', tagName];
-        if (sign || typeof message === 'string') {
-            /**
-             * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
-             */
-            args.push(sign ? '-sm' : '-m', message || '');
-        }
+        const args =
+            sign || typeof message === 'string'
+                ? /**
+                   * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
+                   */
+                  ['tag', tagName, sign ? '-sm' : '-m', message || '']
+                : ['tag', tagName];
         if (debug) {
             const commandText = `git ${commandJoin(args)}`;
             printVerbose(

--- a/src/git.ts
+++ b/src/git.ts
@@ -50,13 +50,13 @@ export async function setTag(
     } = {},
 ): Promise<void> {
     try {
-        const args =
-            sign || typeof message === 'string'
-                ? /**
-                   * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
-                   */
-                  ['tag', tagName, sign ? '-sm' : '-m', message || '']
-                : ['tag', tagName];
+        const args = ['tag', tagName];
+        if (sign || typeof message === 'string') {
+            /**
+             * @see https://github.com/npm/cli/blob/v6.13.0/lib/version.js#L304
+             */
+            args.push(sign ? '-sm' : '-m', message || '');
+        }
         const commandText = `git ${commandJoin(args)}`;
         if (typeof debug === 'function') {
             printVerbose(debug({ commandText, args }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ async function main(opts: Options): Promise<void> {
         await gitTagAlreadyExists(versionTagName, opts);
     } else {
         await setTag(versionTagName, {
+            message: '',
             debug: opts.verbose,
             dryRun: opts.dryRun,
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,7 @@
 import path from 'path';
 
 import { isHeadTag, push, setTag, tagExists } from './git';
-import {
-    endPrintVerbose,
-    getConfig,
-    isPkgData,
-    printVerbose,
-    readJSONFile,
-} from './utils';
+import { endPrintVerbose, getConfig, isPkgData, readJSONFile } from './utils';
 
 export interface Options {
     push?: boolean;
@@ -57,6 +51,7 @@ async function getVersionTagData(): Promise<{
 
 async function gitTagAlreadyExists(
     versionTagName: string,
+    tagMessage: string,
     opts: Options,
 ): Promise<void> {
     if (!(await isHeadTag(versionTagName))) {
@@ -64,9 +59,12 @@ async function gitTagAlreadyExists(
     }
 
     if (opts.verbose) {
-        printVerbose(
-            `> #git tag ${versionTagName}\n  # tag '${versionTagName}' already exists`,
-        );
+        await setTag(versionTagName, {
+            message: tagMessage,
+            debug: ({ commandText }) =>
+                `> #${commandText}\n  # tag '${versionTagName}' already exists`,
+            dryRun: true,
+        });
     }
 }
 
@@ -79,7 +77,7 @@ async function main(opts: Options): Promise<void> {
     const { tagName: versionTagName, message } = await getVersionTagData();
 
     if (await tagExists(versionTagName)) {
-        await gitTagAlreadyExists(versionTagName, opts);
+        await gitTagAlreadyExists(versionTagName, message, opts);
     } else {
         await setTag(versionTagName, {
             message,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ async function gitTagAlreadyExists(
     if (opts.verbose) {
         await setTag(versionTagName, {
             message: tagMessage,
-            debug: ({ commandText }) =>
+            debug: commandText =>
                 `> #${commandText}\n  # tag '${versionTagName}' already exists`,
             dryRun: true,
         });

--- a/test/index.ts
+++ b/test/index.ts
@@ -60,9 +60,9 @@ test('CLI should add Git tag', async t => {
     );
 
     t.regex(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        /^v0\.0\.0$/m,
-        'Git tag v0.0.0 should be added',
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        /^\w+\s+tag\s+refs\/tags\/v0\.0\.0\n$/,
+        'Git annotated tag v0.0.0 should be added',
     );
 });
 
@@ -79,13 +79,13 @@ test('CLI should add Git tag with verbose output', async t => {
         const { stdout, stderr } = await exec([CLI_PATH, '--verbose']);
 
         t.is(stdout, '');
-        t.is(stderr, '\n> git tag v0.0.0\n\n');
+        t.is(stderr, '\n> git tag v0.0.0 -m 0.0.0\n\n');
     }, 'CLI should exits successfully');
 
     t.regex(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        /^v0\.0\.0$/m,
-        'Git tag v0.0.0 should be added',
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        /^\w+\s+tag\s+refs\/tags\/v0\.0\.0\n$/,
+        'Git annotated tag v0.0.0 should be added',
     );
 });
 
@@ -99,7 +99,7 @@ test('CLI should not add Git tag with dry-run', async t => {
         const { stdout, stderr } = await exec([CLI_PATH, '--dry-run']);
 
         t.is(stdout, '');
-        t.is(stderr, 'Dry Run enabled\n\n> git tag v0.0.0\n\n');
+        t.is(stderr, 'Dry Run enabled\n\n> git tag v0.0.0 -m 0.0.0\n\n');
     }, 'CLI should exits successfully');
 
     t.is(
@@ -166,7 +166,7 @@ test('CLI should complete successfully if Git tag has been added with verbose ou
         t.is(stdout, '');
         t.is(
             stderr,
-            `\n> #git tag v0.0.0\n  # tag 'v0.0.0' already exists\n\n`,
+            `\n> #git tag v0.0.0 -m 0.0.0\n  # tag 'v0.0.0' already exists\n\n`,
         );
     }, 'CLI should exits successfully');
 
@@ -201,7 +201,7 @@ test('CLI should complete successfully if Git tag has been added with dry-run', 
         t.is(stdout, '');
         t.is(
             stderr,
-            `Dry Run enabled\n\n> #git tag v0.0.0\n  # tag 'v0.0.0' already exists\n\n`,
+            `Dry Run enabled\n\n> #git tag v0.0.0 -m 0.0.0\n  # tag 'v0.0.0' already exists\n\n`,
         );
     }, 'CLI should exits successfully');
 
@@ -244,7 +244,7 @@ test('CLI should read version and add tag', async t => {
     const patch = getRandomInt(0, 9);
     const version = [major, minor, patch].join('.');
     const versionTagRegExp = new RegExp(
-        `^v${major}\\.${minor}\\.${patch}$`,
+        String.raw`^\w+\s+tag\s+refs/tags/v${major}\.${minor}\.${patch}$`,
         'm',
     );
 
@@ -258,7 +258,7 @@ test('CLI should read version and add tag', async t => {
     await exec(['git', 'commit', '-m', 'Update version']);
 
     t.notRegex(
-        (await exec(['git', 'tag', '-l'])).stdout,
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
         versionTagRegExp,
         `Git tag v${version} should not exist yet`,
     );
@@ -274,9 +274,9 @@ test('CLI should read version and add tag', async t => {
     );
 
     t.regex(
-        (await exec(['git', 'tag', '-l'])).stdout,
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
         versionTagRegExp,
-        `Git tag v${version} should be added`,
+        `Git annotated tag v${version} should be added`,
     );
 });
 
@@ -302,9 +302,9 @@ test('CLI push flag should fail if there is no remote repository', async t => {
     );
 
     t.regex(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        /^v0\.0\.0$/m,
-        'Git tag v0.0.0 should be added',
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        /^\w+\s+tag\s+refs\/tags\/v0\.0\.0\n$/,
+        'Git annotated tag v0.0.0 should be added',
     );
 });
 
@@ -333,9 +333,9 @@ test('CLI should add and push Git tag', async t => {
         );
 
         t.regex(
-            (await exec(['git', 'tag', '-l'])).stdout,
-            /^v0\.0\.0$/m,
-            'Git tag v0.0.0 should be added',
+            (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+            /^\w+\s+tag\s+refs\/tags\/v0\.0\.0\n$/,
+            'Git annotated tag v0.0.0 should be added',
         );
 
         t.deepEqual(
@@ -370,14 +370,15 @@ test('CLI should add and push Git tag with verbose output', async t => {
             t.is(stdout, '');
             t.is(
                 stderr,
-                '\n> git tag v0.0.0\n' + '> git push origin v0.0.0\n\n',
+                '\n> git tag v0.0.0 -m 0.0.0\n' +
+                    '> git push origin v0.0.0\n\n',
             );
         }, 'CLI should exits successfully');
 
         t.regex(
-            (await exec(['git', 'tag', '-l'])).stdout,
-            /^v0\.0\.0$/m,
-            'Git tag v0.0.0 should be added',
+            (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+            /^\w+\s+tag\s+refs\/tags\/v0\.0\.0\n$/,
+            'Git annotated tag v0.0.0 should be added',
         );
 
         t.deepEqual(
@@ -410,7 +411,7 @@ test('CLI should not add and not push Git tag with dry-run', async t => {
         t.is(stdout, '');
         t.is(
             stderr,
-            'Dry Run enabled\n\n> git tag v0.0.0\n> git push origin v0.0.0\n\n',
+            'Dry Run enabled\n\n> git tag v0.0.0 -m 0.0.0\n> git push origin v0.0.0\n\n',
         );
     }, 'CLI should exits successfully');
 
@@ -448,9 +449,9 @@ test('CLI should add and push single Git tag', async t => {
     );
 
     t.regex(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        /^v0\.0\.0$/m,
-        'Git tag v0.0.0 should be added',
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        /^\w+\s+tag\s+refs\/tags\/v0\.0\.0$/m,
+        'Git annotated tag v0.0.0 should be added',
     );
 
     t.deepEqual(tagList, ['v0.0.0'], 'Git tag needs to push only one');
@@ -548,10 +549,13 @@ test('CLI should add Git tag with customized tag prefix by npm', async t => {
     );
 
     const tagName = `${customPrefix}0.0.0`;
-    t.is(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        `${tagName}\n`,
-        `Git tag '${tagName}' should be added`,
+    const versionTagRegExp = new RegExp(
+        String.raw`^\w+\s+tag\s+refs/tags/${escapeRegExp(tagName)}\n$`,
+    );
+    t.regex(
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        versionTagRegExp,
+        `Git annotated tag '${tagName}' should be added`,
     );
 });
 
@@ -602,10 +606,13 @@ test('CLI should add Git tag with customized tag prefix by npm / run npm-script'
     );
 
     const tagName = `${customPrefix}${version}`;
-    t.is(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        `${tagName}\n`,
-        `Git tag '${tagName}' should be added`,
+    const versionTagRegExp = new RegExp(
+        String.raw`^\w+\s+tag\s+refs/tags/${escapeRegExp(tagName)}\n$`,
+    );
+    t.regex(
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        versionTagRegExp,
+        `Git annotated tag '${tagName}' should be added`,
     );
 });
 
@@ -645,10 +652,13 @@ test('CLI should add Git tag with customized tag prefix by yarn', async t => {
     );
 
     const tagName = `${customPrefix}0.0.0`;
-    t.is(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        `${tagName}\n`,
-        `Git tag '${tagName}' should be added`,
+    const versionTagRegExp = new RegExp(
+        String.raw`^\w+\s+tag\s+refs/tags/${escapeRegExp(tagName)}\n$`,
+    );
+    t.regex(
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        versionTagRegExp,
+        `Git annotated tag '${tagName}' should be added`,
     );
 });
 
@@ -699,9 +709,12 @@ test('CLI should add Git tag with customized tag prefix by yarn / run npm-script
     );
 
     const tagName = `${customPrefix}${version}`;
-    t.is(
-        (await exec(['git', 'tag', '-l'])).stdout,
-        `${tagName}\n`,
-        `Git tag '${tagName}' should be added`,
+    const versionTagRegExp = new RegExp(
+        String.raw`^\w+\s+tag\s+refs/tags/${escapeRegExp(tagName)}\n$`,
+    );
+    t.regex(
+        (await exec(['git', 'for-each-ref', 'refs/tags'])).stdout,
+        versionTagRegExp,
+        `Git annotated tag '${tagName}' should be added`,
     );
 });


### PR DESCRIPTION
> There are two types of Git tags: lightweight and annotated.
> The lightweight tag is only an alias for commit. Annotated tags, on the other hand, contain information such as the tagger name and date.
> Because of this feature, documents on Web state that annotated tags are recommended over lightweight tags.
>
> > A lightweight tag is very much like a branch that doesn’t change — it’s just a pointer to a specific commit.
> >
> > Annotated tags, however, are stored as full objects in the Git database. They’re checksummed; contain the tagger name, email, and date; have a tagging message; and can be signed and verified with GNU Privacy Guard (GPG). It’s generally recommended that you create annotated tags so you can have all this information
> >
> > ─ https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags
>

by #69
