### PR TITLE
Remove "git add" from the command executed by lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,20 +67,17 @@
       "git add ./README.md"
     ],
     "!(package).json|*.{js,yaml,yml}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*.ts": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "README.md": [
       "run-s test:readme --"
     ],
     "package.json": [
       "prettier-package-json --write",
-      "sort-package-json",
-      "git add"
+      "sort-package-json"
     ]
   },
   "ava": {


### PR DESCRIPTION
Since version 10.0.0, [`lint-staged` will automatically add changed files to Git](https://github.com/okonet/lint-staged/tree/v10.1.6#migration).
This behavior is the same as executing the `git add` command manually.

This commit should have been done in PR #109.
But I didn't notice any changes in `lint-staged`.