### PR TITLE
Add "-V" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,84 @@
 
 ## [Unreleased]
 
+### Features
+
+* [#125] - Add `-V` option
+
+### Breaking Changes
+
+* [#125] - Change output format:
+    + ```ShellSession
+      $ package-version-git-tag --version
+      2.0.3
+      ```
+      ↓
+      ```ShellSession
+      $ package-version-git-tag --version
+      package-version-git-tag/2.0.3 darwin-x64 node-v10.18.0
+      ```
+    + ```ShellSession
+      $ package-version-git-tag --help
+      Usage: bin [options]
+
+      Add Git tag corresponding to the version field of package.json
+
+      Options:
+        -v, --version  output the version number
+        --push         `git push` the added tag to the remote repository
+        --verbose      show details of executed git commands
+        -n, --dry-run  perform a trial run with no changes made
+        -h, --help     display help for command
+      ```
+      ↓
+      ```ShellSession
+      $ package-version-git-tag --help
+      package-version-git-tag v2.0.3
+
+      Add Git tag corresponding to the version field of package.json
+
+      Usage:
+        $ package-version-git-tag [options]
+
+      Options:
+        -V, -v, --version  Display version number 
+        -h, --help         Display this message 
+        --push             `git push` the added tag to the remote repository 
+        --verbose          show details of executed git commands 
+        -n, --dry-run      perform a trial run with no changes made 
+      ```
+    + ```ShellSession
+      $ package-version-git-tag --typo-option
+      error: unknown option '--typo-option'
+      ```
+      ↓
+      ```ShellSession
+      $ package-version-git-tag --typo-option
+      unknown option: --typoOption
+      Try `package-version-git-tag --help` for valid options.
+      ```
+
 ### Supported Node version
 
 `>=8.3.0` -> `8.3.0 - 14.x`
 
 * [#122] - Support Node.js 14
 
+### Added Dependencies
+
+#### dependencies
+
+* [#125] - `cac@6.5.8`
+
+### Removed Dependencies
+
+#### dependencies
+
+* [#125] - `commander`
+
 [Unreleased]: https://github.com/sounisi5011/package-version-git-tag/compare/v2.0.3...master
 [#122]: https://github.com/sounisi5011/package-version-git-tag/pull/122
+[#125]: https://github.com/sounisi5011/package-version-git-tag/pull/125
 
 ## [2.0.3] (2020-04-21 UTC)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,19 @@
 ### Breaking Changes
 
 * [#125] - Change output format:
+
     + ```ShellSession
       $ package-version-git-tag --version
       2.0.3
       ```
+
       ↓
+
       ```ShellSession
       $ package-version-git-tag --version
       package-version-git-tag/2.0.3 darwin-x64 node-v10.18.0
       ```
+
     + ```ShellSession
       $ package-version-git-tag --help
       Usage: bin [options]
@@ -31,7 +35,9 @@
         -n, --dry-run  perform a trial run with no changes made
         -h, --help     display help for command
       ```
+
       ↓
+
       ```ShellSession
       $ package-version-git-tag --help
       package-version-git-tag v2.0.3
@@ -48,11 +54,14 @@
         --verbose          show details of executed git commands 
         -n, --dry-run      perform a trial run with no changes made 
       ```
+
     + ```ShellSession
       $ package-version-git-tag --typo-option
       error: unknown option '--typo-option'
       ```
+
       ↓
+
       ```ShellSession
       $ package-version-git-tag --typo-option
       unknown option: --typoOption

--- a/README.md
+++ b/README.md
@@ -24,16 +24,19 @@ npm install package-version-git-tag
 
 ```ShellSession
 $ package-version-git-tag --help
-Usage: package-version-git-tag [options]
+package-version-git-tag v2.0.3
 
 Add Git tag corresponding to the version field of package.json
 
+Usage:
+  $ package-version-git-tag [options]
+
 Options:
-  -v, --version  output the version number
-  --push         `git push` the added tag to the remote repository
-  --verbose      show details of executed git commands
-  -n, --dry-run  perform a trial run with no changes made
-  -h, --help     display help for command
+  -V, -v, --version  Display version number 
+  -h, --help         Display this message 
+  --push             `git push` the added tag to the remote repository 
+  --verbose          show details of executed git commands 
+  -n, --dry-run      perform a trial run with no changes made 
 ```
 
 For example, suppose that `package.json` exists in the current directory, and version is `1.2.3`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1477,7 +1477,8 @@
     "commander": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
-      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
+      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
+      "dev": true
     },
     "common-path-prefix": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,6 +1104,11 @@
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
+    "cac": {
+      "version": "6.5.8",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.5.8.tgz",
+      "integrity": "sha512-jLv2+ps4T2HRVR1k4UlQZoAFvliAhf5LVR0yjPjIaIr/Cw99p/I7CXIEkXtw5q+AkYk4NCFJcF5ErmELSyrZnw=="
+    },
     "cacheable-request": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     ]
   },
   "dependencies": {
+    "cac": "6.5.8",
     "command-join": "3.0.0",
     "commander": "5.0.0",
     "cross-spawn": "7.0.2"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   "dependencies": {
     "cac": "6.5.8",
     "command-join": "3.0.0",
-    "commander": "5.0.0",
     "cross-spawn": "7.0.2"
   },
   "devDependencies": {

--- a/readme-template.mustache
+++ b/readme-template.mustache
@@ -30,16 +30,19 @@ npm install {{{pkg.name}}}
 
 ```ShellSession
 $ {{{pkg.name}}} --help
-Usage: {{{pkg.name}}} [options]
+{{{pkg.name}}} v{{{pkg.version}}}
 
 Add Git tag corresponding to the version field of package.json
 
+Usage:
+  $ {{{pkg.name}}} [options]
+
 Options:
-  -v, --version  output the version number
-  --push         `git push` the added tag to the remote repository
-  --verbose      show details of executed git commands
-  -n, --dry-run  perform a trial run with no changes made
-  -h, --help     display help for command
+  -V, -v, --version  Display version number 
+  -h, --help         Display this message 
+  --push             `git push` the added tag to the remote repository 
+  --verbose          show details of executed git commands 
+  -n, --dry-run      perform a trial run with no changes made 
 ```
 
 For example, suppose that `package.json` exists in the current directory, and version is `1.2.3`:

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -13,15 +13,9 @@ const pkg = (() => {
     let version: string | undefined;
     let description = '';
     if (isObject(PKG)) {
-        if (typeof PKG.name === 'string') {
-            name = PKG.name;
-        }
-        if (typeof PKG.version === 'string') {
-            version = PKG.version;
-        }
-        if (typeof PKG.description === 'string') {
-            description = PKG.description;
-        }
+        if (typeof PKG.name === 'string') name = PKG.name;
+        if (typeof PKG.version === 'string') version = PKG.version;
+        if (typeof PKG.description === 'string') description = PKG.description;
     }
 
     return { name, version, description };

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -37,31 +37,36 @@ if (cli.commands.length <= 0) {
     cli.usage('[options]');
 }
 
-const { options } = cli.parse();
-if (options.version || options.help) {
-    process.exit();
-}
+(() => {
+    const { options } = cli.parse();
 
-const unknownOptions = Object.keys(options).filter(
-    (name) => name !== '--' && !cli.globalCommand.hasOption(name),
-);
-if (unknownOptions.length > 0) {
-    process.exitCode = 1;
-    console.error(
-        `unknown ${unknownOptions.length > 1 ? 'options' : 'option'}: ` +
-            `${unknownOptions
-                .map((name) => (/^[^-]$/.test(name) ? `-${name}` : `--${name}`))
-                .join(' ')}\n` +
-            `Try \`${cli.name} --help\` for valid options.`,
+    if (options.version || options.help) {
+        return;
+    }
+
+    const unknownOptions = Object.keys(options).filter(
+        (name) => name !== '--' && !cli.globalCommand.hasOption(name),
     );
-    process.exit();
-}
+    if (unknownOptions.length > 0) {
+        process.exitCode = 1;
+        console.error(
+            `unknown ${unknownOptions.length > 1 ? 'options' : 'option'}: ` +
+                `${unknownOptions
+                    .map((name) =>
+                        /^[^-]$/.test(name) ? `-${name}` : `--${name}`,
+                    )
+                    .join(' ')}\n` +
+                `Try \`${cli.name} --help\` for valid options.`,
+        );
+        return;
+    }
 
-main({
-    push: options.push,
-    verbose: options.verbose,
-    dryRun: options.dryRun,
-}).catch((error) => {
-    process.exitCode = 1;
-    console.error(error instanceof Error ? error.message : error);
-});
+    main({
+        push: options.push,
+        verbose: options.verbose,
+        dryRun: options.dryRun,
+    }).catch((error) => {
+        process.exitCode = 1;
+        console.error(error instanceof Error ? error.message : error);
+    });
+})();

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -47,9 +47,10 @@ if (unknownOptions.length > 0) {
     process.exitCode = 1;
     console.error(
         `unknown ${unknownOptions.length > 1 ? 'options' : 'option'}: ` +
-            unknownOptions
+            `${unknownOptions
                 .map((name) => (/^[^-]$/.test(name) ? `-${name}` : `--${name}`))
-                .join(' '),
+                .join(' ')}\n` +
+            `Try \`${cli.name} --help\` for valid options.`,
     );
     process.exit();
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,24 +5,36 @@ import { cac } from 'cac';
 import main from './';
 import { isObject } from './utils';
 
-const cli = cac();
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const PKG: unknown = require('../package.json');
+const pkg = (() => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const PKG: unknown = require('../package.json');
 
-let description = '';
-if (isObject(PKG)) {
-    if (typeof PKG.version === 'string') {
-        cli.version(PKG.version, '-V, -v, --version');
+    let name: string | undefined;
+    let version: string | undefined;
+    let description = '';
+    if (isObject(PKG)) {
+        if (typeof PKG.name === 'string') {
+            name = PKG.name;
+        }
+        if (typeof PKG.version === 'string') {
+            version = PKG.version;
+        }
+        if (typeof PKG.description === 'string') {
+            description = PKG.description;
+        }
     }
 
-    if (typeof PKG.description === 'string') {
-        description = PKG.description;
-    }
+    return { name, version, description };
+})();
+
+const cli = cac(pkg.name);
+if (pkg.version) {
+    cli.version(pkg.version, '-V, -v, --version');
 }
 cli.help(
-    description
+    pkg.description
         ? (sections) => {
-              sections.splice(1, 0, { body: description });
+              sections.splice(1, 0, { body: pkg.description });
           }
         : undefined,
 );

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,33 +1,63 @@
 #!/usr/bin/env node
 
-import program from 'commander';
+import { cac } from 'cac';
 
 import main from './';
 import { isObject } from './utils';
 
+const cli = cac();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const PKG: unknown = require('../package.json');
 
+let description = '';
 if (isObject(PKG)) {
     if (typeof PKG.version === 'string') {
-        program.version(PKG.version, '-v, --version');
+        cli.version(PKG.version, '-V, -v, --version');
     }
 
     if (typeof PKG.description === 'string') {
-        program.description(PKG.description);
+        description = PKG.description;
     }
 }
+cli.help(
+    description
+        ? (sections) => {
+              sections.splice(1, 0, { body: description });
+          }
+        : undefined,
+);
 
-program
-    .option('--push', '`git push` the added tag to the remote repository')
-    .option('--verbose', 'show details of executed git commands')
-    .option('-n, --dry-run', 'perform a trial run with no changes made')
-    .parse(process.argv);
+cli.option('--push', '`git push` the added tag to the remote repository');
+cli.option('--verbose', 'show details of executed git commands');
+cli.option('-n, --dry-run', 'perform a trial run with no changes made');
+
+if (cli.commands.length <= 0) {
+    cli.usage('[options]');
+}
+
+const { options } = cli.parse();
+if (options.version || options.help) {
+    process.exit();
+}
+
+const unknownOptions = Object.keys(options).filter(
+    (name) => name !== '--' && !cli.globalCommand.hasOption(name),
+);
+if (unknownOptions.length > 0) {
+    process.exitCode = 1;
+    console.error(
+        `unknown ${unknownOptions.length > 1 ? 'options' : 'option'}: ` +
+            unknownOptions
+                .map((name) => (/^[^-]$/.test(name) ? `-${name}` : `--${name}`))
+                .join(' '),
+    );
+    process.exit();
+}
 
 main({
-    push: program.push,
-    verbose: program.verbose,
-    dryRun: program.dryRun,
+    push: options.push,
+    verbose: options.verbose,
+    dryRun: options.dryRun,
 }).catch((error) => {
     process.exitCode = 1;
     console.error(error instanceof Error ? error.message : error);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,30 +5,26 @@ import { cac } from 'cac';
 import main from './';
 import { isObject } from './utils';
 
-const pkg = (() => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const PKG: unknown = require('../package.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const PKG: unknown = require('../package.json');
 
-    let name: string | undefined;
-    let version: string | undefined;
-    let description = '';
-    if (isObject(PKG)) {
-        if (typeof PKG.name === 'string') name = PKG.name;
-        if (typeof PKG.version === 'string') version = PKG.version;
-        if (typeof PKG.description === 'string') description = PKG.description;
-    }
+let pkgName: string | undefined;
+let pkgVersion: string | undefined;
+let pkgDescription = '';
+if (isObject(PKG)) {
+    if (typeof PKG.name === 'string') pkgName = PKG.name;
+    if (typeof PKG.version === 'string') pkgVersion = PKG.version;
+    if (typeof PKG.description === 'string') pkgDescription = PKG.description;
+}
 
-    return { name, version, description };
-})();
-
-const cli = cac(pkg.name);
-if (pkg.version) {
-    cli.version(pkg.version, '-V, -v, --version');
+const cli = cac(pkgName);
+if (pkgVersion) {
+    cli.version(pkgVersion, '-V, -v, --version');
 }
 cli.help(
-    pkg.description
+    pkgDescription
         ? (sections) => {
-              sections.splice(1, 0, { body: pkg.description });
+              sections.splice(1, 0, { body: pkgDescription });
           }
         : undefined,
 );

--- a/test/index.ts
+++ b/test/index.ts
@@ -481,6 +481,40 @@ test('CLI should to display version', async (t) => {
     }
 });
 
+test('CLI should to display version by npx', async (t) => {
+    const { exec } = await initGit(tmpDir('display-version-npx'));
+
+    const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
+
+    await t.notThrowsAsync(exec(['npm', 'install', PROJECT_ROOT]));
+    for (const option of ['--version', '-v', '-V']) {
+        await t.notThrowsAsync(async () => {
+            const { stdout, stderr } = await exec([
+                'npx',
+                '--no-install',
+                PKG_DATA.name,
+                option,
+            ]);
+            t.is(
+                stdout,
+                `${PKG_DATA.name}/${PKG_DATA.version} ${process.platform}-${process.arch} node-${process.version}\n`,
+                `CLI should output version number in stdout / "${option}" option`,
+            );
+            t.is(
+                stderr,
+                '',
+                `CLI should not output anything in stderr / "${option}" option`,
+            );
+        }, `CLI should exits successfully / "${option}" option`);
+
+        t.is(
+            (await exec(['git', 'tag', '-l'])).stdout,
+            gitTags,
+            `Git tag should not change / "${option}" option`,
+        );
+    }
+});
+
 test('CLI should to display help', async (t) => {
     const { exec } = await initGit(tmpDir('display-help'));
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -481,40 +481,6 @@ test('CLI should to display version', async (t) => {
     }
 });
 
-test('CLI should to display version by npx', async (t) => {
-    const { exec } = await initGit(tmpDir('display-version-npx'));
-
-    const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
-
-    await t.notThrowsAsync(exec(['npm', 'install', PROJECT_ROOT]));
-    for (const option of ['--version', '-v', '-V']) {
-        await t.notThrowsAsync(async () => {
-            const { stdout, stderr } = await exec([
-                'npx',
-                '--no-install',
-                PKG_DATA.name,
-                option,
-            ]);
-            t.is(
-                stdout,
-                `${PKG_DATA.name}/${PKG_DATA.version} ${process.platform}-${process.arch} node-${process.version}\n`,
-                `CLI should output version number in stdout / "${option}" option`,
-            );
-            t.is(
-                stderr,
-                '',
-                `CLI should not output anything in stderr / "${option}" option`,
-            );
-        }, `CLI should exits successfully / "${option}" option`);
-
-        t.is(
-            (await exec(['git', 'tag', '-l'])).stdout,
-            gitTags,
-            `Git tag should not change / "${option}" option`,
-        );
-    }
-});
-
 test('CLI should to display help', async (t) => {
     const { exec } = await initGit(tmpDir('display-help'));
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -453,18 +453,32 @@ test('CLI should add and push single Git tag', async (t) => {
     t.deepEqual(tagList, ['v0.0.0'], 'Git tag needs to push only one');
 });
 
-test('CLI should support "--version" option', async (t) => {
+test('CLI should to display version', async (t) => {
     const { exec } = await initGit(tmpDir('display-version'));
 
-    await t.notThrowsAsync(async () => {
-        const { stdout, stderr } = await exec([CLI_PATH, '--version']);
-        t.regex(
-            stdout,
-            new RegExp(`^${escapeRegExp(PKG_DATA.version)}$`, 'm'),
-            'CLI should output version number in stdout',
+    const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
+
+    for (const option of ['--version', '-v', '-V']) {
+        await t.notThrowsAsync(async () => {
+            const { stdout, stderr } = await exec([CLI_PATH, option]);
+            t.regex(
+                stdout,
+                new RegExp(`^${escapeRegExp(PKG_DATA.version)}$`, 'm'),
+                `CLI should output version number in stdout / "${option}" option`,
+            );
+            t.is(
+                stderr,
+                '',
+                `CLI should not output anything in stderr / "${option}" option`,
+            );
+        }, `CLI should exits successfully / "${option}" option`);
+
+        t.is(
+            (await exec(['git', 'tag', '-l'])).stdout,
+            gitTags,
+            `Git tag should not change / "${option}" option`,
         );
-        t.is(stderr, '', 'CLI should not output anything in stderr');
-    }, 'CLI should exits successfully');
+    }
 });
 
 test('CLI should to display help', async (t) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -461,9 +461,9 @@ test('CLI should to display version', async (t) => {
     for (const option of ['--version', '-v', '-V']) {
         await t.notThrowsAsync(async () => {
             const { stdout, stderr } = await exec([CLI_PATH, option]);
-            t.regex(
+            t.is(
                 stdout,
-                new RegExp(`^${escapeRegExp(PKG_DATA.version)}$`, 'm'),
+                `${PKG_DATA.name}/${PKG_DATA.version} ${process.platform}-${process.arch} node-${process.version}\n`,
                 `CLI should output version number in stdout / "${option}" option`,
             );
             t.is(
@@ -488,11 +488,25 @@ test('CLI should to display help', async (t) => {
 
     await t.notThrowsAsync(async () => {
         const { stdout, stderr } = await exec([CLI_PATH, '--help']);
-        t.regex(stdout, /^Usage: /, 'CLI should output help in stdout');
-        t.regex(
+        t.is(
             stdout,
-            new RegExp(`^${escapeRegExp(PKG_DATA.description)}$`, 'm'),
-            'CLI should include description in help',
+            [
+                `${PKG_DATA.name} v${PKG_DATA.version}`,
+                '',
+                PKG_DATA.description,
+                '',
+                'Usage:',
+                `  $ ${PKG_DATA.name} [options]`,
+                '',
+                'Options:',
+                '  -V, -v, --version  Display version number ',
+                '  -h, --help         Display this message ',
+                '  --push             `git push` the added tag to the remote repository ',
+                '  --verbose          show details of executed git commands ',
+                '  -n, --dry-run      perform a trial run with no changes made ',
+                '',
+            ].join('\n'),
+            'CLI should output help in stdout',
         );
         t.is(stderr, '', 'CLI should not output anything in stderr');
     }, 'CLI should exits successfully');
@@ -509,11 +523,22 @@ test('CLI should not work with unknown options', async (t) => {
 
     const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
 
+    const unknownOption = '--lololololololololololololololol';
     await t.throwsAsync(
         exec([CLI_PATH, '--lololololololololololololololol']),
         {
             name: 'CommandFailedError',
-            message: /^e (.+ )?unknown option/m,
+            message: new RegExp(
+                `^stderr:\n${escapeRegExp(
+                    [
+                        `unknown option: ${unknownOption}`,
+                        `Try \`${PKG_DATA.name} --help\` for valid options.`,
+                    ]
+                        .map((line) => `e ${line}`)
+                        .join('\n'),
+                )}$`,
+                'm',
+            ),
         },
         'CLI should fail',
     );


### PR DESCRIPTION
Add `-V` option which is an alias of `--version` option.
In addition, replace [the `commander` package][commander] with [the `cac` package][cac].

[commander]: https://www.npmjs.com/package/commander/v/5.0.0
[cac]: https://www.npmjs.com/package/cac

- [x] Add test
- [x] Add [`cac`][cac]
- [x] Remove [`commander`][commander]
- [x] Fix CLI code
- [x] Update `README.md`
- [x] Update `CHANGELOG.md`
