### PR TITLE
Fix error handling of Git.listen() method in node-git-server

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -38,6 +38,8 @@ overrides:
       - simple-import-sort
     rules:
       no-dupe-class-members: off
+      # The no-unused-expressions rule does not support optional chaining operator (`?.`)
+      no-unused-expressions: off
       node/no-unsupported-features/es-syntax:
         - error
         - ignores:
@@ -47,6 +49,13 @@ overrides:
         - warn
         - allowExpressions: true
       "@typescript-eslint/no-inferrable-types": off
+      # Copy the no-unused-expressions rule's option contained in eslint-config-standard
+      # see: https://github.com/standard/eslint-config-standard/blob/v14.1.1/eslintrc.json#L157
+      "@typescript-eslint/no-unused-expressions":
+        - error
+        - allowShortCircuit: true
+          allowTernary: true
+          allowTaggedTemplates: true
       simple-import-sort/sort: error
   - files: "*.d.ts"
     rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@
 
 * [#137] - `@sounisi5011/check-peer-deps`
 
+### Tests
+
+* [#146] - Fix error handling of `Git.listen()` method in node-git-server
+
 ### Others
 
 * [#136] - Pin only devDependencies
@@ -73,6 +77,7 @@
 [#134]: https://github.com/sounisi5011/package-version-git-tag/pull/134
 [#131]: https://github.com/sounisi5011/package-version-git-tag/pull/131
 [#133]: https://github.com/sounisi5011/package-version-git-tag/pull/133
+[#146]: https://github.com/sounisi5011/package-version-git-tag/pull/146
 
 ## [2.1.0] (2020-04-30 UTC)
 

--- a/test/helpers/git-server.ts
+++ b/test/helpers/git-server.ts
@@ -31,25 +31,29 @@ export default async function (
         if (usedPort.has(port)) {
             continue;
         }
-        try {
-            await new Promise((resolve, reject) => {
-                repos.listen(port, resolve);
-                /**
-                 * Note: The try...catch statement does not catch the error for the http/https module.
-                 * @see https://github.com/expressjs/express/issues/2856#issuecomment-172566787
-                 */
-                repos.server?.on('error', reject);
+        const result = await new Promise((resolve, reject) => {
+            repos.listen(port, resolve);
+            /**
+             * Note: The try...catch statement does not catch the error for the http/https module.
+             * @see https://github.com/expressjs/express/issues/2856#issuecomment-172566787
+             */
+            repos.server?.on('error', reject);
+        })
+            .then(() => {
+                usedPort.add(port);
+                return {
+                    remoteURL: `http://localhost:${port}`,
+                    repos,
+                    tagList,
+                };
+            })
+            .catch((error) => {
+                if (error.code !== 'EADDRINUSE') {
+                    errors.push(error);
+                }
             });
-            usedPort.add(port);
-            return {
-                remoteURL: `http://localhost:${port}`,
-                repos,
-                tagList,
-            };
-        } catch (error) {
-            if (error.code !== 'EADDRINUSE') {
-                errors.push(error);
-            }
+        if (result) {
+            return result;
         }
     }
 

--- a/test/helpers/git-server.ts
+++ b/test/helpers/git-server.ts
@@ -32,7 +32,14 @@ export default async function (
             continue;
         }
         try {
-            await new Promise((resolve) => repos.listen(port, resolve));
+            await new Promise((resolve, reject) => {
+                repos.listen(port, resolve);
+                /**
+                 * Note: The try...catch statement does not catch the error for the http/https module.
+                 * @see https://github.com/expressjs/express/issues/2856#issuecomment-172566787
+                 */
+                repos.server?.on('error', reject);
+            });
             usedPort.add(port);
             return {
                 remoteURL: `http://localhost:${port}`,

--- a/test/helpers/git-server.ts
+++ b/test/helpers/git-server.ts
@@ -26,6 +26,7 @@ export default async function (
         tag.accept();
     });
 
+    const errors: Error[] = [];
     for (let port = PORT.MIN; port <= PORT.MAX; port++) {
         if (usedPort.has(port)) {
             continue;
@@ -40,12 +41,17 @@ export default async function (
             };
         } catch (error) {
             if (error.code !== 'EADDRINUSE') {
-                throw error;
+                errors.push(error);
             }
         }
     }
 
-    throw new Error(
-        `Could not start git server; no available port in ${PORT.MIN} to ${PORT.MAX}`,
-    );
+    const lastError = errors.pop();
+    if (lastError) {
+        throw lastError;
+    } else {
+        throw new Error(
+            `Could not start git server; no available port in ${PORT.MIN} to ${PORT.MAX}`,
+        );
+    }
 }

--- a/types.node_modules/node-git-server.d.ts
+++ b/types.node_modules/node-git-server.d.ts
@@ -79,7 +79,7 @@ declare class Git extends EventEmitter {
     public on(event: 'head', listener: (head: Git.ListenerArg) => void): this;
 
     private dirMap: (dir?: string) => string;
-    private server:
+    public server?:
         | ReturnType<typeof http.createServer>
         | ReturnType<typeof https.createServer>;
 }


### PR DESCRIPTION
In rare cases, the `Git.listen()` method of [`node-git-server@0.6.1`](https://www.npmjs.com/package/node-git-server/v/0.6.1) throws an error and [the test on CI fails](https://dev.azure.com/sounisi5011/npm%20projects/_build/results?buildId=2266&view=logs&j=261cdef3-2080-5d35-5462-f74a13e89de3&t=756a7576-a6a0-59c0-d40a-2c82db97330a&l=25).
If the test throws this error, treat it as if the port was already in use. That is, try to initialize the Git server on another port.