### PR TITLE
💚 Prevent failure if branch already exists when updating license year

### DIFF
--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.TRIGGER_CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           path: |
             ${{ steps.find-all-license-files.outputs.files }}
-          branchName: ${{ join([ env.branch-name-prefix, 'copyright-to-{{currentYear}}' ], '') }}
+          branchName: ${{ format('{0}copyright-to-{1}', env.branch-name-prefix, '{{currentYear}}') }}
           commitTitle: |
             📄 Update copyright year(s)
           prTitle: |

--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "5 0 1 1 *" # 20xx-01-01 00:05
   workflow_dispatch: # Allow manual execution as well, in case the update fails.
+env:
+  branch-name-prefix: license/
 jobs:
   update-license-year:
     runs-on: ubuntu-latest
@@ -23,6 +25,16 @@ jobs:
             echo "${delimiter}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Fetch already existing branches
+        # FantasticFiasco/action-update-license-year@v2 tries to checkout the remote branch it has detected.
+        # However, since it has not yet been fetched, the "git checkout" command fails.
+        # see https://github.com/FantasticFiasco/action-update-license-year/blob/v2.3.0/src/main.js#L65
+        shell: bash
+        run: |
+          git ls-remote --heads origin '${{ env.branch-name-prefix }}*' | awk '{ print $2 }' | while read -r refspec; do
+            git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "${refspec#refs/heads/}"
+          done
+
       - uses: FantasticFiasco/action-update-license-year@v2
         with:
           # Use personal access token instead of GITHUB_TOKEN to execute CI for pull requests.
@@ -30,6 +42,7 @@ jobs:
           token: ${{ secrets.TRIGGER_CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           path: |
             ${{ steps.find-all-license-files.outputs.files }}
+          branchName: ${{ join([ env.branch-name-prefix, 'copyright-to-{{currentYear}}' ], '') }}
           commitTitle: |
             📄 Update copyright year(s)
           prTitle: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Because it is the minimum version available for Vitest.
 * [#198] - Update old Corepack that throw ENOTEMPTY or EPERM errors
 * [#199] - Lock file maintenance
 * [#202] - Add a workflow to auto update the license year
+* [#207] - Prevent failure if branch already exists when updating license year
 
 [#182]: https://github.com/sounisi5011/package-version-git-tag/pull/182
 [#183]: https://github.com/sounisi5011/package-version-git-tag/pull/183
@@ -156,6 +157,7 @@ Because it is the minimum version available for Vitest.
 [#199]: https://github.com/sounisi5011/package-version-git-tag/pull/199
 [#200]: https://github.com/sounisi5011/package-version-git-tag/pull/200
 [#202]: https://github.com/sounisi5011/package-version-git-tag/pull/202
+[#207]: https://github.com/sounisi5011/package-version-git-tag/pull/207
 
 ## [3.0.0] (2020-06-02 UTC)
 


### PR DESCRIPTION
FantasticFiasco/action-update-license-year@v2 tries to checkout the remote branch it has detected.
However, since it has not yet been fetched, the "git checkout" command fails.
see https://github.com/FantasticFiasco/action-update-license-year/blob/v2.3.0/src/main.js#L65