### PR TITLE
🐛 Fix edge cases in CLI argument parsing process

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -39,6 +39,7 @@
         "ts-node",
         "vite", // This is needed for vitest
         "vitest",
+        "vitest-mock-process",
       ],
       groupName: "dependencies: test packages",
       groupSlug: "tester-packages",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Because it is the minimum version available for Vitest.
 
     This is needed for vitest.
 * [#200] - `vitest@0.29.2`
+* [#210] - `vitest-mock-process@1.0.4`
 
 ### Removed Dependencies
 
@@ -160,6 +161,7 @@ Because it is the minimum version available for Vitest.
 [#202]: https://github.com/sounisi5011/package-version-git-tag/pull/202
 [#207]: https://github.com/sounisi5011/package-version-git-tag/pull/207
 [#208]: https://github.com/sounisi5011/package-version-git-tag/pull/208
+[#210]: https://github.com/sounisi5011/package-version-git-tag/pull/210
 
 ## [3.0.0] (2020-06-02 UTC)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 [Unreleased]: https://github.com/sounisi5011/package-version-git-tag/compare/v3.0.0...master
 
 * Drop support for Node.js 10 and 12
+* Fix edge cases in CLI argument parsing process
+* Update dev dependencies
 
 ### Supported Node version
 
@@ -26,6 +28,10 @@ Because it is the minimum version available for Vitest.
 * [#200] - Migrate from AVA to Vitest
 
 [contributor:johnschult]: https://github.com/johnschult
+
+### Fixed
+
+* [#210] - Fix edge cases in CLI argument parsing process
 
 ### Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "ts-node": "10.9.1",
         "typescript": "4.9.5",
         "vite": "4.1.4",
-        "vitest": "0.29.2"
+        "vitest": "0.29.2",
+        "vitest-mock-process": "1.0.4"
       },
       "engines": {
         "node": "^14.14.0 || 16.x || >=18.x"
@@ -1729,6 +1730,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-clone-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-clone-fn/-/deep-clone-fn-1.1.0.tgz",
+      "integrity": "sha512-9EOa4OcoQhpBknAVdyVjlCFEtHD8lyC/P84NUy+FiJumMs9AQ39vNPvq8IySYjTqTqgO5ZAd2Bm+ATSjNKA/gw==",
+      "dev": true,
+      "dependencies": {
+        "rfdc": "^1.3.0"
       }
     },
     "node_modules/deep-eql": {
@@ -5829,6 +5839,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6820,6 +6836,18 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-mock-process": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vitest-mock-process/-/vitest-mock-process-1.0.4.tgz",
+      "integrity": "sha512-WFoSE8MLTanQJkZUZSEd2/9+O1RJKqYn5tUNh3mW/SAh1VL7D7cfcxkn2F7DlhsFI0ZPILxto0OI6XEmGYFyRA==",
+      "dev": true,
+      "dependencies": {
+        "deep-clone-fn": "^1.1.0"
+      },
+      "peerDependencies": {
+        "vitest": "<1"
       }
     },
     "node_modules/vitest/node_modules/cac": {
@@ -8105,6 +8133,15 @@
           "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
           "dev": true
         }
+      }
+    },
+    "deep-clone-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-clone-fn/-/deep-clone-fn-1.1.0.tgz",
+      "integrity": "sha512-9EOa4OcoQhpBknAVdyVjlCFEtHD8lyC/P84NUy+FiJumMs9AQ39vNPvq8IySYjTqTqgO5ZAd2Bm+ATSjNKA/gw==",
+      "dev": true,
+      "requires": {
+        "rfdc": "^1.3.0"
       }
     },
     "deep-eql": {
@@ -11061,6 +11098,12 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11752,6 +11795,15 @@
           "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
           "dev": true
         }
+      }
+    },
+    "vitest-mock-process": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vitest-mock-process/-/vitest-mock-process-1.0.4.tgz",
+      "integrity": "sha512-WFoSE8MLTanQJkZUZSEd2/9+O1RJKqYn5tUNh3mW/SAh1VL7D7cfcxkn2F7DlhsFI0ZPILxto0OI6XEmGYFyRA==",
+      "dev": true,
+      "requires": {
+        "deep-clone-fn": "^1.1.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "ts-node": "10.9.1",
     "typescript": "4.9.5",
     "vite": "4.1.4",
-    "vitest": "0.29.2"
+    "vitest": "0.29.2",
+    "vitest-mock-process": "1.0.4"
   },
   "packageManager": "npm@7.24.2",
   "engines": {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,6 +5,10 @@ import { cac } from 'cac';
 import main from './';
 import { isObject } from './utils';
 
+function isTruthyOpt(option: unknown): boolean {
+    return option !== undefined && option !== false;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const PKG: unknown = require('../package.json');
 
@@ -63,9 +67,9 @@ if (cli.commands.length <= 0) {
     }
 
     main({
-        push: Boolean(options['push']),
-        verbose: Boolean(options['verbose']),
-        dryRun: Boolean(options['dryRun']),
+        push: isTruthyOpt(options['push']),
+        verbose: isTruthyOpt(options['verbose']),
+        dryRun: isTruthyOpt(options['dryRun']),
     }).catch((error) => {
         process.exitCode = 1;
         console.error(error instanceof Error ? error.message : error);

--- a/src/bin/argv.ts
+++ b/src/bin/argv.ts
@@ -29,7 +29,7 @@ export interface ParseArgvResult {
 }
 
 function isTruthyOpt(option: unknown): boolean {
-    return option !== undefined && option !== false;
+    return option !== undefined && option !== false && option !== 'false';
 }
 
 function genHelpCallback(

--- a/src/bin/argv.ts
+++ b/src/bin/argv.ts
@@ -1,0 +1,82 @@
+import { cac } from 'cac';
+
+export interface ParseArgvOptions {
+    /**
+     * The program name to display in help and version message.
+     */
+    readonly name: string | undefined;
+    /**
+     * version number.
+     * Empty strings are ignored.
+     */
+    readonly version: string | undefined;
+    /**
+     * Description to be included in help.
+     * Empty strings are ignored
+     */
+    readonly description: string | undefined;
+}
+
+export interface ParseArgvResult {
+    name: string;
+    isHelpMode: boolean;
+    options: {
+        push: boolean;
+        verbose: boolean;
+        dryRun: boolean;
+    };
+    unknownOptions: string[];
+}
+
+function isTruthyOpt(option: unknown): boolean {
+    return option !== undefined && option !== false;
+}
+
+/**
+ * Note: If the "--help" or "--version" option is passed to argv, this function writes to `process.stdout`.
+ */
+export function parseArgv(
+    argv: readonly string[],
+    opts: ParseArgvOptions,
+): ParseArgvResult {
+    const cli = cac(opts.name);
+    if (opts.version) {
+        cli.version(opts.version, '-V, -v, --version');
+    }
+    if (opts.description) {
+        // TypeScript warns: The "description" property may be undefined value inside a function.
+        // So, we assign it to the variable "body" here.
+        const body = opts.description;
+        cli.help((sections) => {
+            sections.splice(1, 0, { body });
+        });
+    } else {
+        cli.help();
+    }
+
+    cli.option('--push', '`git push` the added tag to the remote repository');
+    cli.option('--verbose', 'show details of executed git commands');
+    cli.option('-n, --dry-run', 'perform a trial run with no changes made');
+
+    if (cli.commands.length <= 0) {
+        cli.usage('[options]');
+    }
+
+    const { options } = cli.parse([...argv]);
+
+    return {
+        name: cli.name,
+        isHelpMode:
+            isTruthyOpt(options['version']) || isTruthyOpt(options['help']),
+        options: {
+            push: isTruthyOpt(options['push']),
+            verbose: isTruthyOpt(options['verbose']),
+            dryRun: isTruthyOpt(options['dryRun']),
+        },
+        unknownOptions: Object.keys(options)
+            .filter(
+                (name) => name !== '--' && !cli.globalCommand.hasOption(name),
+            )
+            .map((name) => (/^[^-]$/.test(name) ? `-${name}` : `--${name}`)),
+    };
+}

--- a/test/cli-args.ts
+++ b/test/cli-args.ts
@@ -173,6 +173,74 @@ describe('--help option', () => {
     );
 });
 
+describe('--push option', () => {
+    const optionNameList = ['--push'];
+    it.each(truthyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'the push option should be true',
+            ).toMatchObject({
+                options: {
+                    push: true,
+                },
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+    it.each(falsyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'the push option should be false',
+            ).toMatchObject({
+                options: {
+                    push: false,
+                },
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+});
+
+describe('--verbose option', () => {
+    const optionNameList = ['--verbose'];
+    it.each(truthyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'the verbose option should be true',
+            ).toMatchObject({
+                options: {
+                    verbose: true,
+                },
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+    it.each(falsyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'the verbose option should be false',
+            ).toMatchObject({
+                options: {
+                    verbose: false,
+                },
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+});
+
 describe('--dry-run option', () => {
     const optionNameList = ['-n', '--dry-run', '--dryRun'];
     it.each(truthyOptsCases(optionNameList))('%s', (_, options) =>
@@ -205,4 +273,50 @@ describe('--dry-run option', () => {
             expect(mocks.log).toHaveBeenCalledTimes(0);
         }),
     );
+});
+
+test('unknown options should be detected', () => {
+    expect(
+        parseArgv(
+            [
+                '',
+                '',
+                '-xy',
+                '--z',
+                '--un-known',
+                '--inValid',
+                '--sameName',
+                '--sameName',
+                '--camelCaseVsKebabCase',
+                '--camel-case-vs-kebab-case',
+                '--kebab-case-vs-camel-case',
+                '--kebabCaseVsCamelCase',
+                '--has-value=hoge',
+                '--',
+                'ignored',
+            ],
+            parseArgvOpts,
+        ).unknownOptions,
+    ).toStrictEqual([
+        // Should return the actual hyphen-minus used, not the inferred hyphen-minus based on option length.
+        '-x',
+        '-y',
+        '--z',
+        // If the kebab-case option is passed, this should be returned.
+        // Note: cac converts the case style of the option name from kebab-case to lowerCamelCase.
+        //       Raw CLI arguments must be parsed to detect options passed.
+        '--un-known',
+        // If the lowerCamelCase option is passed, this should be returned.
+        // Please return the actual option passed without converting lowerCamelCase to kebab-case.
+        '--inValid',
+        // Duplicate options should not be returned.
+        '--sameName',
+        // The same options, differing only in case style, should be returned in the order in which they were actually passed.
+        '--camelCaseVsKebabCase',
+        '--camel-case-vs-kebab-case',
+        '--kebab-case-vs-camel-case',
+        '--kebabCaseVsCamelCase',
+        // Character "=" and after should be ignored.
+        '--has-value',
+    ]);
 });

--- a/test/cli-args.ts
+++ b/test/cli-args.ts
@@ -1,0 +1,208 @@
+import { commandJoin } from 'command-join';
+import { describe, expect, it, test } from 'vitest';
+import {
+    mockConsoleLog,
+    mockProcessStderr,
+    mockProcessStdout,
+} from 'vitest-mock-process';
+
+import { parseArgv, type ParseArgvOptions } from '../src/bin/argv';
+
+function truthyOptsCases(
+    optionNameList: readonly string[],
+): [name: string, options: string[]][] {
+    return optionNameList
+        .flatMap((optionName) => [
+            [optionName],
+            // A number of 0 is a falsy value, but a string of "0" is a truthy value.
+            // The CLI should evaluate all these values as strings and treat them as truthy values.
+            // Note: Exclude "false", since "false" may need to be treated as a falsy value.
+            ...[
+                'foo',
+                'undefined',
+                'null',
+                'true',
+                '1',
+                '0',
+                '+0',
+                '-0',
+                'NaN',
+            ].flatMap((optionValue) => [
+                ...(optionValue.startsWith('-')
+                    ? []
+                    : [[optionName, optionValue]]),
+                [`${optionName}=${optionValue}`],
+            ]),
+        ])
+        .map((options) => [commandJoin(options), options]);
+}
+
+function falsyOptsCases(
+    optionNameList: readonly string[],
+): [name: string, options: string[]][] {
+    return optionNameList
+        .flatMap((optionName) => [
+            [`--no-${optionName.replace(/^-{1,2}/, '')}`],
+            [optionName, `--no-${optionName.replace(/^-{1,2}/, '')}`],
+            ...['false'].flatMap((optionValue) => [
+                ...(optionValue.startsWith('-')
+                    ? []
+                    : [[optionName, optionValue]]),
+                [`${optionName}=${optionValue}`],
+            ]),
+        ])
+        .map((options) => [commandJoin(options), options]);
+}
+
+function mockStdioRun<T>(
+    fn: (mocks: {
+        readonly stdout: ReturnType<typeof mockProcessStdout>;
+        readonly stderr: ReturnType<typeof mockProcessStderr>;
+        readonly log: ReturnType<typeof mockConsoleLog>;
+    }) => T,
+): T {
+    const mocks = {
+        stdout: mockProcessStdout(),
+        stderr: mockProcessStderr(),
+        log: mockConsoleLog(),
+    };
+    const result = fn(mocks);
+    for (const mocker of Object.values(mocks)) {
+        mocker.mockRestore();
+    }
+    return result;
+}
+
+// ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- //
+
+const parseArgvOpts = {
+    name: 'summon-dragon',
+    version: '1.2.3',
+    description: 'Tools used to summon dragons from other worlds',
+} as const satisfies ParseArgvOptions;
+
+test('by default, all options should be false', () =>
+    mockStdioRun((mocks) => {
+        expect(parseArgv(['', ''], parseArgvOpts).options).toStrictEqual({
+            push: false,
+            verbose: false,
+            dryRun: false,
+        });
+        expect(mocks.stdout).toHaveBeenCalledTimes(0);
+        expect(mocks.stderr).toHaveBeenCalledTimes(0);
+        expect(mocks.log).toHaveBeenCalledTimes(0);
+    }));
+
+describe('--version option', () => {
+    const optionNameList = ['-V', '-v', '--version'];
+    it.each(truthyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'isHelpMode should be true',
+            ).toMatchObject({
+                isHelpMode: true,
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(1);
+            expect(mocks.log).toHaveBeenCalledWith(
+                `${parseArgvOpts.name}/${parseArgvOpts.version} ${process.platform}-${process.arch} node-${process.version}`,
+            );
+        }),
+    );
+    it.each(falsyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'isHelpMode should be false',
+            ).toMatchObject({
+                isHelpMode: false,
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+});
+
+describe('--help option', () => {
+    const optionNameList = ['-h', '--help'];
+    it.each(truthyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'isHelpMode should be true',
+            ).toMatchObject({
+                isHelpMode: true,
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(1);
+            expect(mocks.log).toHaveBeenCalledWith(
+                [
+                    `${parseArgvOpts.name} v${parseArgvOpts.version}`,
+                    '',
+                    parseArgvOpts.description,
+                    '',
+                    'Usage:',
+                    `  $ ${parseArgvOpts.name} [options]`,
+                    '',
+                    'Options:',
+                    '  -V, -v, --version  Display version number ',
+                    '  -h, --help         Display this message ',
+                    '  --push             `git push` the added tag to the remote repository ',
+                    '  --verbose          show details of executed git commands ',
+                    '  -n, --dry-run      perform a trial run with no changes made ',
+                ].join('\n'),
+            );
+        }),
+    );
+    it.each(falsyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'isHelpMode should be false',
+            ).toMatchObject({
+                isHelpMode: false,
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+});
+
+describe('--dry-run option', () => {
+    const optionNameList = ['-n', '--dry-run', '--dryRun'];
+    it.each(truthyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'the dry-run option should be true',
+            ).toMatchObject({
+                options: {
+                    dryRun: true,
+                },
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+    it.each(falsyOptsCases(optionNameList))('%s', (_, options) =>
+        mockStdioRun((mocks) => {
+            expect(
+                parseArgv(['', '', ...options], parseArgvOpts),
+                'the dry-run option should be false',
+            ).toMatchObject({
+                options: {
+                    dryRun: false,
+                },
+            });
+            expect(mocks.stdout).toHaveBeenCalledTimes(0);
+            expect(mocks.stderr).toHaveBeenCalledTimes(0);
+            expect(mocks.log).toHaveBeenCalledTimes(0);
+        }),
+    );
+});

--- a/test/cli-args.ts
+++ b/test/cli-args.ts
@@ -276,47 +276,52 @@ describe('--dry-run option', () => {
 });
 
 test('unknown options should be detected', () => {
-    expect(
-        parseArgv(
-            [
-                '',
-                '',
-                '-xy',
-                '--z',
-                '--un-known',
-                '--inValid',
-                '--sameName',
-                '--sameName',
-                '--camelCaseVsKebabCase',
-                '--camel-case-vs-kebab-case',
-                '--kebab-case-vs-camel-case',
-                '--kebabCaseVsCamelCase',
-                '--has-value=hoge',
-                '--',
-                'ignored',
-            ],
-            parseArgvOpts,
-        ).unknownOptions,
-    ).toStrictEqual([
-        // Should return the actual hyphen-minus used, not the inferred hyphen-minus based on option length.
-        '-x',
-        '-y',
-        '--z',
-        // If the kebab-case option is passed, this should be returned.
-        // Note: cac converts the case style of the option name from kebab-case to lowerCamelCase.
-        //       Raw CLI arguments must be parsed to detect options passed.
-        '--un-known',
-        // If the lowerCamelCase option is passed, this should be returned.
-        // Please return the actual option passed without converting lowerCamelCase to kebab-case.
-        '--inValid',
-        // Duplicate options should not be returned.
-        '--sameName',
-        // The same options, differing only in case style, should be returned in the order in which they were actually passed.
-        '--camelCaseVsKebabCase',
-        '--camel-case-vs-kebab-case',
-        '--kebab-case-vs-camel-case',
-        '--kebabCaseVsCamelCase',
-        // Character "=" and after should be ignored.
-        '--has-value',
-    ]);
+    mockStdioRun((mocks) => {
+        expect(
+            parseArgv(
+                [
+                    '',
+                    '',
+                    '-xy',
+                    '--z',
+                    '--un-known',
+                    '--inValid',
+                    '--sameName',
+                    '--sameName',
+                    '--camelCaseVsKebabCase',
+                    '--camel-case-vs-kebab-case',
+                    '--kebab-case-vs-camel-case',
+                    '--kebabCaseVsCamelCase',
+                    '--has-value=hoge',
+                    '--',
+                    'ignored',
+                ],
+                parseArgvOpts,
+            ).unknownOptions,
+        ).toStrictEqual([
+            // Should return the actual hyphen-minus used, not the inferred hyphen-minus based on option length.
+            '-x',
+            '-y',
+            '--z',
+            // If the kebab-case option is passed, this should be returned.
+            // Note: cac converts the case style of the option name from kebab-case to lowerCamelCase.
+            //       Raw CLI arguments must be parsed to detect options passed.
+            '--un-known',
+            // If the lowerCamelCase option is passed, this should be returned.
+            // Please return the actual option passed without converting lowerCamelCase to kebab-case.
+            '--inValid',
+            // Duplicate options should not be returned.
+            '--sameName',
+            // The same options, differing only in case style, should be returned in the order in which they were actually passed.
+            '--camelCaseVsKebabCase',
+            '--camel-case-vs-kebab-case',
+            '--kebab-case-vs-camel-case',
+            '--kebabCaseVsCamelCase',
+            // Character "=" and after should be ignored.
+            '--has-value',
+        ]);
+        expect(mocks.stdout).toHaveBeenCalledTimes(0);
+        expect(mocks.stderr).toHaveBeenCalledTimes(0);
+        expect(mocks.log).toHaveBeenCalledTimes(0);
+    });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,7 @@
+import { commandJoin } from 'command-join';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { beforeAll, expect, test } from 'vitest';
+import { beforeAll, describe, expect, it, test } from 'vitest';
 
 import * as PKG_DATA from '../package.json';
 import { execFileAsync, getRandomInt, rmrf } from './helpers';
@@ -19,6 +20,35 @@ const CLI_PATH = path.resolve(
 
 function tmpDir(dirname: string): string {
     return path.resolve(__dirname, 'tmp', dirname);
+}
+
+function boolOptsCases(
+    ...opts: readonly string[]
+): [name: string, options: string[]][] {
+    return opts
+        .flatMap((optionName) => [
+            [optionName],
+            // A number of 0 is a falsy value, but a string of "0" is a truthy value.
+            // The CLI should evaluate all these values as strings and treat them as truthy values.
+            // Note: Exclude "false", since "false" may need to be treated as a falsy value.
+            ...[
+                'foo',
+                'undefined',
+                'null',
+                'true',
+                '1',
+                '0',
+                '+0',
+                '-0',
+                'NaN',
+            ].flatMap((optionValue) => [
+                ...(optionValue.startsWith('-')
+                    ? []
+                    : [[optionName, optionValue]]),
+                [`${optionName}=${optionValue}`],
+            ]),
+        ])
+        .map((options) => [commandJoin(options), options]);
 }
 
 beforeAll(async () => {
@@ -88,25 +118,33 @@ test('CLI should add Git tag with verbose output', async () => {
     });
 });
 
-test('CLI should not add Git tag with dry-run', async () => {
-    const { exec } = await initGit(tmpDir('not-exists-git-tag-with-dry-run'));
+describe('CLI should not add Git tag with dry-run', () => {
+    it.each(boolOptsCases('-n', '--dry-run'))('%s', async (_, options) => {
+        const { exec } = await initGit(
+            tmpDir('not-exists-git-tag-with-dry-run'),
+        );
 
-    const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
-    expect(gitTags, 'Git tag should not exist yet').toBe('');
+        const gitTagsResult = exec(['git', 'tag', '-l']);
+        await expect(
+            gitTagsResult,
+            'Git tag should not exist yet',
+        ).resolves.toMatchObject({ stdout: '', stderr: '' });
+        const { stdout: gitTags } = await gitTagsResult;
 
-    await expect(
-        exec([CLI_PATH, '--dry-run']),
-        'CLI should exits successfully',
-    ).resolves.toMatchObject({
-        stdout: '',
-        stderr: 'Dry Run enabled\n\n> git tag v0.0.0 -m 0.0.0\n',
-    });
+        await expect(
+            exec([CLI_PATH, ...options]),
+            'CLI should exits successfully',
+        ).resolves.toMatchObject({
+            stdout: '',
+            stderr: 'Dry Run enabled\n\n> git tag v0.0.0 -m 0.0.0\n',
+        });
 
-    await expect(
-        exec(['git', 'tag', '-l']),
-        'Git tag should not change',
-    ).resolves.toMatchObject({
-        stdout: gitTags,
+        await expect(
+            exec(['git', 'tag', '-l']),
+            'Git tag should not change',
+        ).resolves.toMatchObject({
+            stdout: gitTags,
+        });
     });
 });
 
@@ -422,60 +460,75 @@ test('CLI should add and push single Git tag', async () => {
     expect(tagList, 'Git tag needs to push only one').toStrictEqual(['v0.0.0']);
 });
 
-test('CLI should to display version', async () => {
-    const { exec } = await initGit(tmpDir('display-version'));
+describe('CLI should to display version', () => {
+    it.each(boolOptsCases('-V', '-v', '--version'))(
+        '%s',
+        async (_, options) => {
+            const { exec } = await initGit(tmpDir('display-version'));
 
-    const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
+            const gitTagsResult = exec(['git', 'tag', '-l']);
+            await expect(
+                gitTagsResult,
+                'Git tag should not exist yet',
+            ).resolves.toMatchObject({ stdout: '', stderr: '' });
+            const { stdout: gitTags } = await gitTagsResult;
 
-    for (const option of ['--version', '-v', '-V']) {
+            await expect(
+                exec([CLI_PATH, ...options]),
+                'CLI should output version number',
+            ).resolves.toMatchObject({
+                stdout: `${PKG_DATA.name}/${PKG_DATA.version} ${process.platform}-${process.arch} node-${process.version}`,
+                stderr: '',
+            });
+
+            await expect(
+                exec(['git', 'tag', '-l']),
+                'Git tag should not change',
+            ).resolves.toMatchObject({
+                stdout: gitTags,
+            });
+        },
+    );
+});
+
+describe('CLI should to display help', () => {
+    it.each(boolOptsCases('-h', '--help'))('%s', async (_, options) => {
+        const { exec } = await initGit(tmpDir('display-help'));
+
+        const gitTagsResult = exec(['git', 'tag', '-l']);
         await expect(
-            exec([CLI_PATH, option]),
-            `CLI should output version number / "${option}" option`,
+            gitTagsResult,
+            'Git tag should not exist yet',
+        ).resolves.toMatchObject({ stdout: '', stderr: '' });
+        const { stdout: gitTags } = await gitTagsResult;
+
+        await expect(
+            exec([CLI_PATH, ...options]),
+            'CLI should output help',
         ).resolves.toMatchObject({
-            stdout: `${PKG_DATA.name}/${PKG_DATA.version} ${process.platform}-${process.arch} node-${process.version}`,
+            stdout: [
+                `${PKG_DATA.name} v${PKG_DATA.version}`,
+                '',
+                PKG_DATA.description,
+                '',
+                'Usage:',
+                `  $ ${PKG_DATA.name} [options]`,
+                '',
+                'Options:',
+                '  -V, -v, --version  Display version number ',
+                '  -h, --help         Display this message ',
+                '  --push             `git push` the added tag to the remote repository ',
+                '  --verbose          show details of executed git commands ',
+                '  -n, --dry-run      perform a trial run with no changes made ',
+            ].join('\n'),
             stderr: '',
         });
 
         await expect(
             exec(['git', 'tag', '-l']),
-            `Git tag should not change / "${option}" option`,
-        ).resolves.toMatchObject({
-            stdout: gitTags,
-        });
-    }
-});
-
-test('CLI should to display help', async () => {
-    const { exec } = await initGit(tmpDir('display-help'));
-
-    const gitTags = (await exec(['git', 'tag', '-l'])).stdout;
-
-    await expect(
-        exec([CLI_PATH, '--help']),
-        'CLI should output help',
-    ).resolves.toMatchObject({
-        stdout: [
-            `${PKG_DATA.name} v${PKG_DATA.version}`,
-            '',
-            PKG_DATA.description,
-            '',
-            'Usage:',
-            `  $ ${PKG_DATA.name} [options]`,
-            '',
-            'Options:',
-            '  -V, -v, --version  Display version number ',
-            '  -h, --help         Display this message ',
-            '  --push             `git push` the added tag to the remote repository ',
-            '  --verbose          show details of executed git commands ',
-            '  -n, --dry-run      perform a trial run with no changes made ',
-        ].join('\n'),
-        stderr: '',
+            'Git tag should not change',
+        ).resolves.toMatchObject({ stdout: gitTags });
     });
-
-    await expect(
-        exec(['git', 'tag', '-l']),
-        'Git tag should not change',
-    ).resolves.toMatchObject({ stdout: gitTags });
 });
 
 test('CLI should not work with unknown options', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     test: {
         include: ['test/**/*.ts'],
         exclude: [...configDefaults.exclude, '**/helpers/**'],
+        deps: {
+            inline: ['vitest-mock-process'],
+        },
         testTimeout: m(5),
         hookTimeout: m(5),
         watchExclude: [


### PR DESCRIPTION
After examining the source code for the `cac` package, I found that it is possible to pass values for the boolean options as well.

Some values may be evaluated as falsy.
However, boolean options should not evaluate to different results depending on the value.