### PR TITLE
🎨 Migrate from `cac` to `mri`

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -62,14 +62,6 @@
       matchUpdateTypes: ["major"],
       enabled: false,
     },
-    // The format of help messages has changed since cac 6.7.0.
-    // see https://github.com/cacjs/cac/commit/e565b2ae5d4a3256ed4d56a64d91356e7d6cbce6
-    // We should not update until we introduce breaking changes that modify the help messages.
-    {
-      matchPackageNames: ["cac"],
-      matchCurrentVersion: "<6.7.0",
-      enabled: false,
-    },
     // `escape-string-regexp@>=5.0.0` doesn't work with old Node.js.
     // Because it uses pure ESM.
     // We should only update if the Node.js support range: `>=14.13.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Unreleased]: https://github.com/sounisi5011/package-version-git-tag/compare/v3.0.0...master
 
 * Drop support for Node.js 10 and 12
+* Migrate from [`cac`](https://www.npmjs.com/package/cac/v/6.6.1) to [`mri`](https://www.npmjs.com/package/mri/v/1.2.0)
 * Fix edge cases in CLI argument parsing process
 * Update dev dependencies
 
@@ -38,14 +39,6 @@ Because it is the minimum version available for Vitest.
 * [#182] - From now on, use squash merges
 
 ### Updated Dependencies
-
-#### dependencies
-
-* `cac`
-    * [#185] - `^6.5.8` -> `6.5.8 - 6.6.x`
-
-    The format of help messages has changed since cac 6.7.0.
-    see https://github.com/cacjs/cac/commit/e565b2ae5d4a3256ed4d56a64d91356e7d6cbce6
 
 #### devDependencies
 
@@ -97,6 +90,10 @@ Because it is the minimum version available for Vitest.
 
 ### Added Dependencies
 
+#### dependencies
+
+* [#211] - `mri@^1.2.0`
+
 #### devDependencies
 
 * [#186] - `@tsconfig/node14@1.0.3`
@@ -113,6 +110,10 @@ Because it is the minimum version available for Vitest.
 * [#210] - `vitest-mock-process@1.0.4`
 
 ### Removed Dependencies
+
+#### dependencies
+
+* [#211] - `cac`
 
 #### devDependencies
 
@@ -147,6 +148,7 @@ Because it is the minimum version available for Vitest.
 * [#202] - Add a workflow to auto update the license year
 * [#207] - Prevent failure if branch already exists when updating license year
 * [#208] - Update copyright year(s)
+* [#211] - Migrate from [`cac`](https://www.npmjs.com/package/cac/v/6.6.1) to [`mri`](https://www.npmjs.com/package/mri/v/1.2.0)
 
 [#182]: https://github.com/sounisi5011/package-version-git-tag/pull/182
 [#183]: https://github.com/sounisi5011/package-version-git-tag/pull/183
@@ -168,6 +170,7 @@ Because it is the minimum version available for Vitest.
 [#207]: https://github.com/sounisi5011/package-version-git-tag/pull/207
 [#208]: https://github.com/sounisi5011/package-version-git-tag/pull/208
 [#210]: https://github.com/sounisi5011/package-version-git-tag/pull/210
+[#211]: https://github.com/sounisi5011/package-version-git-tag/pull/211
 
 ## [3.0.0] (2020-06-02 UTC)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "cac": "6.5.8 - 6.6.x",
         "command-join": "^3.0.0",
         "cross-spawn": "^7.0.2",
         "mri": "^1.2.0"
@@ -1349,9 +1348,10 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.6.1.tgz",
-      "integrity": "sha512-uhki4T3Ax68hw7Dufi0bATVAF8ayBSwOKUEJHjObPrUN4tlQ8Lf7oljpTje/mArLxYN0D743c2zJt4C1bVTCqg==",
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6773,15 +6773,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/vite-node/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/vitest": {
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.29.2.tgz",
@@ -6857,15 +6848,6 @@
       },
       "peerDependencies": {
         "vitest": "<1"
-      }
-    },
-    "node_modules/vitest/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/which": {
@@ -7855,9 +7837,10 @@
       }
     },
     "cac": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.6.1.tgz",
-      "integrity": "sha512-uhki4T3Ax68hw7Dufi0bATVAF8ayBSwOKUEJHjObPrUN4tlQ8Lf7oljpTje/mArLxYN0D743c2zJt4C1bVTCqg=="
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true
     },
     "call-bind": {
       "version": "1.0.2",
@@ -11761,14 +11744,6 @@
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
-      },
-      "dependencies": {
-        "cac": {
-          "version": "6.7.14",
-          "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-          "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-          "dev": true
-        }
       }
     },
     "vitest": {
@@ -11801,14 +11776,6 @@
         "vite": "^3.0.0 || ^4.0.0",
         "vite-node": "0.29.2",
         "why-is-node-running": "^2.2.2"
-      },
-      "dependencies": {
-        "cac": {
-          "version": "6.7.14",
-          "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-          "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-          "dev": true
-        }
       }
     },
     "vitest-mock-process": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "cac": "6.5.8 - 6.6.x",
         "command-join": "^3.0.0",
-        "cross-spawn": "^7.0.2"
+        "cross-spawn": "^7.0.2",
+        "mri": "^1.2.0"
       },
       "bin": {
         "package-version-git-tag": "dist/bin.js"
@@ -4589,6 +4590,14 @@
         "pathe": "^1.1.0",
         "pkg-types": "^1.0.2",
         "ufo": "^1.1.1"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -10194,6 +10203,11 @@
         "pkg-types": "^1.0.2",
         "ufo": "^1.1.1"
       }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   "dependencies": {
     "cac": "6.5.8 - 6.6.x",
     "command-join": "^3.0.0",
-    "cross-spawn": "^7.0.2"
+    "cross-spawn": "^7.0.2",
+    "mri": "^1.2.0"
   },
   "devDependencies": {
     "@sounisi5011/readme-generator": "github:sounisi5011/readme-generator#semver:0.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "test:unit-test": "vitest"
   },
   "dependencies": {
-    "cac": "6.5.8 - 6.6.x",
     "command-join": "^3.0.0",
     "cross-spawn": "^7.0.2",
     "mri": "^1.2.0"

--- a/src/bin/argv.ts
+++ b/src/bin/argv.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import * as path from 'path';
 
 import mri = require('mri');
 import {

--- a/src/bin/options.ts
+++ b/src/bin/options.ts
@@ -53,7 +53,7 @@ function kebabCase2lowerCamelCase(str: string): string {
     return str.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
 }
 
-function cmpOptionName(a: string, b: string): -1 | 0 | 1 {
+function cmpOptionName(a: ValidOptionName, b: ValidOptionName): -1 | 0 | 1 {
     const aLen = a.length;
     const bLen = b.length;
     if (aLen === 1 && aLen < bLen) return -1;

--- a/src/bin/options.ts
+++ b/src/bin/options.ts
@@ -1,0 +1,157 @@
+/* eslint @typescript-eslint/restrict-template-expressions: ["error", {allowNumber:true, allowBoolean:true}] */
+
+import type {
+    OptionDefinition,
+    OptionDefRecord,
+    ValidOptionName,
+} from './options.types';
+
+// ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- //
+// If you want to add more options, edit under this.
+// If you add a new `OptionDefRecord` object, remember to merge it into the `allOptions` variable.
+
+export const boolOptions = {
+    version: {
+        description: 'Display version number',
+        alias: ['V', 'v'],
+    },
+    help: {
+        description: 'Display this message',
+        alias: ['h'],
+    },
+    push: {
+        description: '`git push` the added tag to the remote repository',
+    },
+    verbose: {
+        description: 'show details of executed git commands',
+    },
+    'dry-run': {
+        description: 'perform a trial run with no changes made',
+        alias: ['n'],
+    },
+} as const satisfies OptionDefRecord;
+
+export const allOptions = { ...boolOptions } as const;
+
+// Do not edit down from here.
+// ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- //
+
+type DeepReadonly<T> = T extends Set<infer V> | ReadonlySet<infer V>
+    ? ReadonlySet<DeepReadonly<V>>
+    : {
+          readonly [P in keyof T]: DeepReadonly<T[P]>;
+      };
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const toReadonly = <T>(v: T) => v as DeepReadonly<T>;
+
+const fromEntries: <K extends string, V>(
+    entries: Iterable<readonly [K, V]>,
+) => Record<K, V> = Object.fromEntries;
+
+function kebabCase2lowerCamelCase(str: string): string {
+    return str.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
+}
+
+function cmpOptionName(a: string, b: string): -1 | 0 | 1 {
+    const aLen = a.length;
+    const bLen = b.length;
+    if (aLen === 1 && aLen < bLen) return -1;
+    if (bLen === 1 && bLen < aLen) return 1;
+
+    /**
+     * Sort strings based on UTF-16 code point order.
+     * This order does not sort surrogate pairs correctly.
+     * (for example, U+1F916 (🤖) is same as "U+D83E U+DD16", and 0xD83E < 0xFB00, so it is sorted before U+FB00 (ﬀ)).
+     * However, this is not a problem because only ASCII characters are expected to be included in the option names.
+     * (`mri@1.2.0`'s implementation also does not consider surrogate pairs).
+     */
+    if (a < b) return -1;
+    if (b < a) return 1;
+
+    return 0;
+}
+
+const getAllOptionsEntries: <K extends ValidOptionName>(
+    o: Record<K, OptionDefinition>,
+) => [K, OptionDefinition][] = Object.entries;
+const allOptionsEntries = toReadonly(getAllOptionsEntries(allOptions));
+const aliasEntries = toReadonly(
+    allOptionsEntries.map(
+        ([name, { alias }]) =>
+            [
+                name,
+                // Note: This array contains duplicate option names.
+                //       We could exclude them with a Set object, but we don't because `mri@1.2.0` works fine.
+                (alias ?? [])
+                    .concat(name)
+                    .flatMap((k) => [k, kebabCase2lowerCamelCase(k)]),
+            ] satisfies [ValidOptionName, readonly string[]],
+    ),
+);
+
+/**
+ * A set of all option names.
+ * All option names not included in this set should be warned as unknown options.
+ * @example
+ * new Set([
+ *     'version',
+ *     'V',
+ *     'v',
+ *     'help',
+ *     ...
+ * ])
+ */
+export const knownOptionNameSet = toReadonly(new Set(aliasEntries.flat(2)));
+
+/**
+ * Return writable aliasRecord objects
+ * @example
+ * {
+ *     version: ['V', 'v'],
+ *     push: [],
+ *     ...
+ * }
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getAliasRecord = () =>
+    fromEntries(
+        aliasEntries.map(([name, alias]) => [name, [...alias]]),
+    ) satisfies Record<keyof typeof allOptions, string[]>;
+
+/**
+ * @example
+ * [
+ *     '-V, -v, --version  Display version number',
+ *     '-h, --help         Display this message',
+ *     ...
+ * ]
+ */
+export function genOptionTextList(): string[] {
+    const optionDataList = allOptionsEntries.map<
+        [
+            name: string,
+            description: OptionDefinition['description'],
+            defaultValue: OptionDefinition['defaultValue'],
+        ]
+    >(([name, { alias = [], description, defaultValue }]) => [
+        [name, ...alias]
+            .sort(cmpOptionName)
+            .map((name) => (name.length === 1 ? `-${name}` : `--${name}`))
+            .join(', '),
+        description,
+        defaultValue,
+    ]);
+    const nameLengthMax = optionDataList
+        .map(([name]) => name.length)
+        .reduce((a, b) => Math.max(a, b), 0);
+    /**
+     * @see https://github.com/cacjs/cac/blob/v6.6.1/src/Command.ts#L192-L202
+     */
+    return optionDataList.map(
+        ([name, description, defaultValue]) =>
+            `${name.padEnd(nameLengthMax, ' ')}  ${description}${
+                defaultValue !== undefined ? ` (default: ${defaultValue})` : ''
+            }`,
+    );
+}

--- a/src/bin/options.types.ts
+++ b/src/bin/options.types.ts
@@ -1,0 +1,24 @@
+type CharUnion<T extends string> = T extends `${infer Char}${infer Str}`
+    ? Char | CharUnion<Str>
+    : never;
+type AsciiLetterChar = CharUnion<'abcdefghijklmnopqrstuvwxyz'>;
+type AsciiDigitChar = CharUnion<'0123456789'>;
+
+/**
+ * @note We wanted this type to be "a string allowing only kebab cases", but that was probably not possible.
+ */
+export type ValidOptionName =
+    // String of one or more lengths allowing all characters except uppercase
+    | `${AsciiLetterChar | AsciiDigitChar}${Lowercase<string>}`
+    // Allow uppercase if only one letter
+    | Uppercase<AsciiLetterChar>;
+
+export interface OptionDefinition {
+    readonly description: string;
+    readonly alias?: readonly ValidOptionName[];
+    readonly defaultValue?: string | number | boolean;
+}
+
+export type OptionDefRecord = Partial<
+    Record<ValidOptionName, OptionDefinition>
+>;


### PR DESCRIPTION
[`mri`](https://npmjs.com/package/mri) is the CLI argument parser [used internally by `cac`](https://github.com/cacjs/cac/blob/v6.6.1/src/CAC.ts#L210).
Since `mri` has only minimal features, we are free to create our own CLI.

+ `mri` does not convert arguments to lowerCamelCase!
    We can know the option names as they are passed to the CLI.
+ `mri` handles Boolean arguments properly!
    The values of "-n false" and "--dry-run false" are both `false`.
+ `mri` doesn't generate versions or help text!
    We can decide all we want to change the output of the CLI.