### PR TITLE
🔧 Enable the `esModuleInterop` option in `tsconfig.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Because it is the minimum version available for Vitest.
 * [#207] - Prevent failure if branch already exists when updating license year
 * [#208] - Update copyright year(s)
 * [#211] - Migrate from [`cac`](https://www.npmjs.com/package/cac/v/6.6.1) to [`mri`](https://www.npmjs.com/package/mri/v/1.2.0)
+* [#213] - Enable the `esModuleInterop` option in `tsconfig.json`
 
 [#182]: https://github.com/sounisi5011/package-version-git-tag/pull/182
 [#183]: https://github.com/sounisi5011/package-version-git-tag/pull/183
@@ -171,6 +172,7 @@ Because it is the minimum version available for Vitest.
 [#208]: https://github.com/sounisi5011/package-version-git-tag/pull/208
 [#210]: https://github.com/sounisi5011/package-version-git-tag/pull/210
 [#211]: https://github.com/sounisi5011/package-version-git-tag/pull/211
+[#213]: https://github.com/sounisi5011/package-version-git-tag/pull/213
 
 ## [3.0.0] (2020-06-02 UTC)
 

--- a/src/bin/argv.ts
+++ b/src/bin/argv.ts
@@ -1,5 +1,5 @@
 import mri from 'mri';
-import * as path from 'path';
+import path from 'path';
 
 import { deepCopy } from '../utils';
 import { boolOptions, genOptionTextList, getAliasRecord } from './options';

--- a/src/bin/argv.ts
+++ b/src/bin/argv.ts
@@ -1,6 +1,6 @@
+import mri from 'mri';
 import * as path from 'path';
 
-import mri = require('mri');
 import { deepCopy } from '../utils';
 import { boolOptions, genOptionTextList, getAliasRecord } from './options';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 
 import { isHeadTag, push, setTag, tagExists } from './git';
 import { endPrintVerbose, getConfig, isPkgData, readJSONFile } from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import type * as childProcess from 'child_process';
+import type childProcess from 'child_process';
 import { commandJoin } from 'command-join';
 import crossSpawn from 'cross-spawn';
-import * as fs from 'fs/promises';
-import * as path from 'path';
-import * as v8 from 'v8';
+import fs from 'fs/promises';
+import path from 'path';
+import v8 from 'v8';
 
 export interface PkgDataInterface {
     version: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,9 @@
 import type * as childProcess from 'child_process';
 import { commandJoin } from 'command-join';
+import crossSpawn from 'cross-spawn';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as v8 from 'v8';
-
-import crossSpawn = require('cross-spawn');
 
 export interface PkgDataInterface {
     version: string;

--- a/test/helpers/git.ts
+++ b/test/helpers/git.ts
@@ -1,8 +1,8 @@
+import execa from 'execa';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import { rmrf } from '.';
-import execa = require('execa');
 import initGitServer from './git-server';
 import type { PromiseValue } from './types';
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,4 @@
+import escapeRegExp from 'escape-string-regexp';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { beforeAll, describe, expect, it, test } from 'vitest';
@@ -5,8 +6,6 @@ import { beforeAll, describe, expect, it, test } from 'vitest';
 import * as PKG_DATA from '../package.json';
 import { execFileAsync, getRandomInt, rmrf } from './helpers';
 import { initGit } from './helpers/git';
-
-import escapeRegExp = require('escape-string-regexp');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
 const FIXTURES_DIR = path.resolve(__dirname, 'fixtures');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,7 @@
     "newLine": "LF",
 
     /* Interop Constraints */
-    "allowSyntheticDefaultImports": false,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
 
     /* Type Checking */


### PR DESCRIPTION
From now on, we will use the ESM compliant default import instead of the deprecated [`import = require()` statement](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require).
