### PR TITLE
✨ Support pnpm

### DIFF
--- a/test/helpers/git.ts
+++ b/test/helpers/git.ts
@@ -50,11 +50,11 @@ export async function initGit(
     const exec: ExecFunc = ([command, ...args], options) =>
         execa(command, args, {
             cwd: gitDirpath,
-            // By default, only the PATH environment variable is inherited.
-            // This is because some tests are broken by inheriting environment variables.
-            env: { PATH: process.env['PATH'] },
             extendEnv: false,
             ...options,
+            // By default, only the PATH environment variable is inherited.
+            // This is because some tests are broken by inheriting environment variables.
+            env: { PATH: process.env['PATH'], ...options?.env },
         });
     const version = [
         getRandomInt(0, 99),


### PR DESCRIPTION
The current code uses the npm command when an unknown package manager is detected.

https://github.com/sounisi5011/package-version-git-tag/blob/dc0f2b180edaf83264e7a6e7fe9221e4a01613cc/src/utils.ts#L165-L199

If Corepack is enabled, the npm command will fail if pnpm is used.
For this reason, pnpm support is needed.