### PR TITLE
💚 Fix Corepack updating process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,14 +192,6 @@ jobs:
           # On Windows we can't use the CLI we installed just by running the "npm install --global ..." command.
           # This function allows use of the installed CLI.
           npm_install_global() {
-            # Older npm may not succeed in global install.
-            # Therefore, if npm is old, update it.
-            if version_lte '7.0' "$(npm --version)"; then
-              :
-            else
-              exec_with_debug npm install --global --force 'npm@7.x'
-            fi
-
             exec_with_debug npm install --global --force "$1"
 
             if [[ '${{ runner.os }}' == 'Windows' ]]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,7 +202,8 @@ jobs:
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "%s\n" "${unixLikeGlobalPath}"
+              printf "%s\n[command]PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
+              PATH="${unixLikeGlobalPath}:${PATH}"
             fi
           }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,7 +201,7 @@ jobs:
               printf "%s\n[command]echo '%s' >> \$GITHUB_PATH\n" "${globalPath}" "${globalPath}"
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
-              local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
+              local -r unixLikeGlobalPath="$(exec_with_debug cygpath --mixed "${globalPath}")"
               printf "%s\n[command]export PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
               export PATH="${unixLikeGlobalPath}:${PATH}"
             fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,43 +64,43 @@ jobs:
       - id: detector
         uses: sounisi5011/npm-packages@actions/get-nodejs-versions-array-v0
 
-  # lint:
-  #   needs: if-run-ci
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
+  lint:
+    needs: if-run-ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - name: Reconfigure git to use HTTP authentication
-  #       # see https://stackoverflow.com/a/69634516
-  #       # see https://github.com/actions/setup-node/issues/214#issuecomment-810829250
-  #       shell: bash
-  #       run: |
-  #         git config --global \
-  #           'url.https://${{ secrets.GITHUB_TOKEN }}@github.com/.insteadOf' \
-  #           'ssh://git@github.com/'
+      - name: Reconfigure git to use HTTP authentication
+        # see https://stackoverflow.com/a/69634516
+        # see https://github.com/actions/setup-node/issues/214#issuecomment-810829250
+        shell: bash
+        run: |
+          git config --global \
+            'url.https://${{ secrets.GITHUB_TOKEN }}@github.com/.insteadOf' \
+            'ssh://git@github.com/'
 
-  #     - name: Install Node.js
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 14.x
-  #         cache: npm
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: npm
 
-  #     - name: Enable Corepack (Automatically setup a package manager for Node.js)
-  #       run: |
-  #         corepack enable
-  #         corepack enable npm
+      - name: Enable Corepack (Automatically setup a package manager for Node.js)
+        run: |
+          corepack enable
+          corepack enable npm
 
-  #     - name: Show node and npm version
-  #       shell: bash
-  #       run: |
-  #         echo node "$(node --version)"
-  #         echo npm "$(npm --version)"
+      - name: Show node and npm version
+        shell: bash
+        run: |
+          echo node "$(node --version)"
+          echo npm "$(npm --version)"
 
-  #     - name: Install dependencies
-  #       run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-  #     - name: Run linter
-  #       run: npm run test:other-than-unit-test
+      - name: Run linter
+        run: npm run test:other-than-unit-test
 
   unit-test:
     needs: detect-supported-node
@@ -284,11 +284,11 @@ jobs:
           echo node "$(node --version)"
           echo npm "$(npm --version)"
 
-      # - name: Install dependencies
-      #   run: npm ci || npm install
+      - name: Install dependencies
+        run: npm ci || npm install
 
-      # - name: Run unit test
-      #   run: npm run test:unit-test
+      - name: Run unit test
+        run: npm run test:unit-test
 
   # Successfully complete this job when all jobs have been completed.
   # Only by checking this job, it is possible to determine if CI is complete or not.
@@ -297,8 +297,7 @@ jobs:
   # see https://github.com/sounisi5011/npm-packages/blob/2a5ca2de696eeb8b40a38de90580441c4c6c96e0/.github/workflows/ci.yaml#L482-L498
   complete:
     name: Complete CI
-    # needs: [lint, unit-test]
-    needs: unit-test
+    needs: [lint, unit-test]
     if:
       ${{ always() && github.event.pull_request }}
       # This job is required only for Pull Requests.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,43 +64,43 @@ jobs:
       - id: detector
         uses: sounisi5011/npm-packages@actions/get-nodejs-versions-array-v0
 
-  lint:
-    needs: if-run-ci
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+  # lint:
+  #   needs: if-run-ci
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Reconfigure git to use HTTP authentication
-        # see https://stackoverflow.com/a/69634516
-        # see https://github.com/actions/setup-node/issues/214#issuecomment-810829250
-        shell: bash
-        run: |
-          git config --global \
-            'url.https://${{ secrets.GITHUB_TOKEN }}@github.com/.insteadOf' \
-            'ssh://git@github.com/'
+  #     - name: Reconfigure git to use HTTP authentication
+  #       # see https://stackoverflow.com/a/69634516
+  #       # see https://github.com/actions/setup-node/issues/214#issuecomment-810829250
+  #       shell: bash
+  #       run: |
+  #         git config --global \
+  #           'url.https://${{ secrets.GITHUB_TOKEN }}@github.com/.insteadOf' \
+  #           'ssh://git@github.com/'
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
-          cache: npm
+  #     - name: Install Node.js
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 14.x
+  #         cache: npm
 
-      - name: Enable Corepack (Automatically setup a package manager for Node.js)
-        run: |
-          corepack enable
-          corepack enable npm
+  #     - name: Enable Corepack (Automatically setup a package manager for Node.js)
+  #       run: |
+  #         corepack enable
+  #         corepack enable npm
 
-      - name: Show node and npm version
-        shell: bash
-        run: |
-          echo node "$(node --version)"
-          echo npm "$(npm --version)"
+  #     - name: Show node and npm version
+  #       shell: bash
+  #       run: |
+  #         echo node "$(node --version)"
+  #         echo npm "$(npm --version)"
 
-      - name: Install dependencies
-        run: npm ci
+  #     - name: Install dependencies
+  #       run: npm ci
 
-      - name: Run linter
-        run: npm run test:other-than-unit-test
+  #     - name: Run linter
+  #       run: npm run test:other-than-unit-test
 
   unit-test:
     needs: detect-supported-node
@@ -281,11 +281,11 @@ jobs:
           echo node "$(node --version)"
           echo npm "$(npm --version)"
 
-      - name: Install dependencies
-        run: npm ci || npm install
+      # - name: Install dependencies
+      #   run: npm ci || npm install
 
-      - name: Run unit test
-        run: npm run test:unit-test
+      # - name: Run unit test
+      #   run: npm run test:unit-test
 
   # Successfully complete this job when all jobs have been completed.
   # Only by checking this job, it is possible to determine if CI is complete or not.
@@ -294,7 +294,8 @@ jobs:
   # see https://github.com/sounisi5011/npm-packages/blob/2a5ca2de696eeb8b40a38de90580441c4c6c96e0/.github/workflows/ci.yaml#L482-L498
   complete:
     name: Complete CI
-    needs: [lint, unit-test]
+    # needs: [lint, unit-test]
+    needs: unit-test
     if:
       ${{ always() && github.event.pull_request }}
       # This job is required only for Pull Requests.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,6 +228,9 @@ jobs:
               echo '::endgroup::'
 
               exec_with_debug corepack --version
+              if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
+                exit 1
+              fi
 
               echo '::group::Enable Corepack'
             fi
@@ -253,6 +256,9 @@ jobs:
             echo '::endgroup::'
 
             exec_with_debug corepack --version
+            if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
+              exit 1
+            fi
 
             echo '::group::Enable Corepack'
             exec_with_debug corepack enable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,6 +231,8 @@ jobs:
 
           if type corepack >/dev/null 2>&1; then
             if version_lte "${COREPACK_MIN_VERSION}" "$(corepack --version)"; then
+              exec_with_debug corepack --version
+
               echo '::group::Try enable Corepack'
             else
               echo "::group::Old Corepack is detected ( corepack@$(corepack --version 2>/dev/null || echo '[Execution failed; Unknown version]') ). Update this"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,6 +227,8 @@ jobs:
               npm_install_global "corepack@${COREPACK_MIN_VERSION}"
               echo '::endgroup::'
 
+              exec_with_debug corepack --version
+
               echo '::group::Enable Corepack'
             fi
             exec_with_debug corepack enable
@@ -249,6 +251,8 @@ jobs:
             fi
             npm_install_global "corepack@${COREPACK_MIN_VERSION}"
             echo '::endgroup::'
+
+            exec_with_debug corepack --version
 
             echo '::group::Enable Corepack'
             exec_with_debug corepack enable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,11 @@ jobs:
           npm_install_global() {
             exec_with_debug npm install --global --force "$1"
 
+            # Clear the bash command cache.
+            # If the package is overwritten, the path to the command may change.
+            # To track this, remove the command cache.
+            exec_with_debug hash -r
+
             if [[ '${{ runner.os }}' == 'Windows' ]]; then
               # Windows installs global packages to a directory that has lower priority than the default node install so we also need to edit $PATH
               # see https://github.com/vercel/turbo/pull/1632/files#diff-b92a3120126a9ffe46d7d5ec3a8496ef1eac951db09e1972fac7c78438e36c42R69

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,8 +197,13 @@ jobs:
             if [[ '${{ runner.os }}' == 'Windows' ]]; then
               # Windows installs global packages to a directory that has lower priority than the default node install so we also need to edit $PATH
               # see https://github.com/vercel/turbo/pull/1632/files#diff-b92a3120126a9ffe46d7d5ec3a8496ef1eac951db09e1972fac7c78438e36c42R69
-              echo "[command]npm config get prefix >> \$GITHUB_PATH"
-              npm config get prefix >> "${GITHUB_PATH}"
+              local -r globalPath="$(exec_with_debug npm config get prefix)"
+              printf "${globalPath}\n[command]echo '${globalPath}' >> \$GITHUB_PATH\n"
+              echo "${globalPath}" >> "${GITHUB_PATH}"
+
+              local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
+              printf "${unixLikeGlobalPath}\n[command]export PATH='${unixLikeGlobalPath}':\$PATH\n"
+              export PATH="${unixLikeGlobalPath}:${PATH}"
             fi
           }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,8 +202,8 @@ jobs:
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "%s\n[command]export PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
-              export PATH="${unixLikeGlobalPath}:${PATH}"
+              printf "%s\n[command]PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
+              PATH="${unixLikeGlobalPath}:${PATH}"
             fi
           }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,6 +232,7 @@ jobs:
               npm_install_global "corepack@${COREPACK_MIN_VERSION}"
               echo '::endgroup::'
 
+              exec_with_debug which corepack
               exec_with_debug corepack --version
               if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
                 exit 1
@@ -260,6 +261,7 @@ jobs:
             npm_install_global "corepack@${COREPACK_MIN_VERSION}"
             echo '::endgroup::'
 
+            exec_with_debug which corepack
             exec_with_debug corepack --version
             if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
               exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,13 +228,9 @@ jobs:
             if version_lte "${COREPACK_MIN_VERSION}" "$(corepack --version)"; then
               echo '::group::Try enable Corepack'
             else
-              echo "PATH: '${PATH}'"
-
               echo "::group::Old Corepack is detected ( corepack@$(corepack --version 2>/dev/null || echo '[Execution failed; Unknown version]') ). Update this"
               npm_install_global "corepack@${COREPACK_MIN_VERSION}"
               echo '::endgroup::'
-
-              echo "PATH: '${PATH}'"
 
               exec_with_debug corepack --version
               if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,9 +223,13 @@ jobs:
             if version_lte "${COREPACK_MIN_VERSION}" "$(corepack --version)"; then
               echo '::group::Try enable Corepack'
             else
+              echo "PATH: '${PATH}'"
+
               echo "::group::Old Corepack is detected ( corepack@$(corepack --version 2>/dev/null || echo '[Execution failed; Unknown version]') ). Update this"
               npm_install_global "corepack@${COREPACK_MIN_VERSION}"
               echo '::endgroup::'
+
+              echo "PATH: '${PATH}'"
 
               exec_with_debug corepack --version
               if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,8 +207,7 @@ jobs:
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "%s\n[command]PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
-              PATH="${unixLikeGlobalPath}:${PATH}"
+              printf "%s\n" "${unixLikeGlobalPath}"
             fi
           }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,6 +192,14 @@ jobs:
           # On Windows we can't use the CLI we installed just by running the "npm install --global ..." command.
           # This function allows use of the installed CLI.
           npm_install_global() {
+            # Older npm may not succeed in global install.
+            # Therefore, if npm is old, update it.
+            if version_lte '7.0' "$(npm --version)"; then
+              :
+            else
+              exec_with_debug npm install --global --force 'npm@7.x'
+            fi
+
             exec_with_debug npm install --global --force "$1"
 
             if [[ '${{ runner.os }}' == 'Windows' ]]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,7 +207,8 @@ jobs:
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "%s\n" "${unixLikeGlobalPath}"
+              printf "%s\n[command]PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
+              PATH="${unixLikeGlobalPath}:${PATH}"
             fi
           }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,9 +238,6 @@ jobs:
               echo '::endgroup::'
 
               exec_with_debug corepack --version
-              if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
-                exit 1
-              fi
 
               echo '::group::Enable Corepack'
             fi
@@ -266,9 +263,6 @@ jobs:
             echo '::endgroup::'
 
             exec_with_debug corepack --version
-            if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
-              exit 1
-            fi
 
             echo '::group::Enable Corepack'
             exec_with_debug corepack enable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,7 +201,7 @@ jobs:
               printf "%s\n[command]echo '%s' >> \$GITHUB_PATH\n" "${globalPath}" "${globalPath}"
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
-              local -r unixLikeGlobalPath="$(exec_with_debug cygpath --mixed "${globalPath}")"
+              local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
               printf "%s\n[command]export PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
               export PATH="${unixLikeGlobalPath}:${PATH}"
             fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,8 +202,7 @@ jobs:
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "%s\n[command]PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
-              PATH="${unixLikeGlobalPath}:${PATH}"
+              printf "%s\n" "${unixLikeGlobalPath}"
             fi
           }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,7 +237,6 @@ jobs:
               npm_install_global "corepack@${COREPACK_MIN_VERSION}"
               echo '::endgroup::'
 
-              exec_with_debug which corepack
               exec_with_debug corepack --version
               if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
                 exit 1
@@ -266,7 +265,6 @@ jobs:
             npm_install_global "corepack@${COREPACK_MIN_VERSION}"
             echo '::endgroup::'
 
-            exec_with_debug which corepack
             exec_with_debug corepack --version
             if [[ "$(corepack --version)" != "${COREPACK_MIN_VERSION}."* ]]; then
               exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,11 +198,11 @@ jobs:
               # Windows installs global packages to a directory that has lower priority than the default node install so we also need to edit $PATH
               # see https://github.com/vercel/turbo/pull/1632/files#diff-b92a3120126a9ffe46d7d5ec3a8496ef1eac951db09e1972fac7c78438e36c42R69
               local -r globalPath="$(exec_with_debug npm config get prefix)"
-              printf "${globalPath}\n[command]echo '${globalPath}' >> \$GITHUB_PATH\n"
+              printf "%s\n[command]echo '%s' >> \$GITHUB_PATH\n" "${globalPath}" "${globalPath}"
               echo "${globalPath}" >> "${GITHUB_PATH}"
 
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "${unixLikeGlobalPath}\n[command]export PATH='${unixLikeGlobalPath}':\$PATH\n"
+              printf "%s\n[command]export PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
               export PATH="${unixLikeGlobalPath}:${PATH}"
             fi
           }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,12 +203,17 @@ jobs:
               # Windows installs global packages to a directory that has lower priority than the default node install so we also need to edit $PATH
               # see https://github.com/vercel/turbo/pull/1632/files#diff-b92a3120126a9ffe46d7d5ec3a8496ef1eac951db09e1972fac7c78438e36c42R69
               local -r globalPath="$(exec_with_debug npm config get prefix)"
-              printf "%s\n[command]echo '%s' >> \$GITHUB_PATH\n" "${globalPath}" "${globalPath}"
-              echo "${globalPath}" >> "${GITHUB_PATH}"
-
+              echo "${globalPath}"
               local -r unixLikeGlobalPath="$(exec_with_debug cygpath --unix "${globalPath}")"
-              printf "%s\n[command]PATH='%s':\$PATH\n" "${unixLikeGlobalPath}" "${unixLikeGlobalPath}"
-              PATH="${unixLikeGlobalPath}:${PATH}"
+              echo "${unixLikeGlobalPath}"
+
+              if [[ "${PATH}" != "${unixLikeGlobalPath}:"* ]]; then
+                echo "[command]echo '${globalPath}' >> \$GITHUB_PATH"
+                echo "${globalPath}" >> "${GITHUB_PATH}"
+
+                echo "[command]PATH='${unixLikeGlobalPath}':\$PATH"
+                PATH="${unixLikeGlobalPath}:${PATH}"
+              fi
             fi
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ Because it is the minimum version available for Vitest.
 * [#211] - Migrate from [`cac`](https://www.npmjs.com/package/cac/v/6.6.1) to [`mri`](https://www.npmjs.com/package/mri/v/1.2.0)
 * [#213] - Enable the `esModuleInterop` option in `tsconfig.json`
 * [#218] - Using Corepack with all Node.js
+* [#219] - Fix Corepack updating process
 
 [#182]: https://github.com/sounisi5011/package-version-git-tag/pull/182
 [#183]: https://github.com/sounisi5011/package-version-git-tag/pull/183
@@ -179,6 +180,7 @@ Because it is the minimum version available for Vitest.
 [#213]: https://github.com/sounisi5011/package-version-git-tag/pull/213
 [#214]: https://github.com/sounisi5011/package-version-git-tag/pull/214
 [#218]: https://github.com/sounisi5011/package-version-git-tag/pull/218
+[#219]: https://github.com/sounisi5011/package-version-git-tag/pull/219
 
 ## [3.0.0] (2020-06-02 UTC)
 


### PR DESCRIPTION
On Windows, the installed Corepack cannot be used without updating the `PATH` environment variable.

https://github.com/sounisi5011/package-version-git-tag/blob/f45eb2f8c8cfce672433f013d3170c402fecc302/.github/workflows/ci.yaml#L197-L202

This is the same within the Bash shell.
In other words, the `corepack` command referenced in subsequent shell scripts is the Corepack before installation.
When the `corepack enable` command is executed, it only activates the old Corepack.

Therefore, the result of the `npm config get prefix` command must be added to the `PATH` environment variable.