### PR TITLE
💚 Ensure that scripts in the "Get the diff from the latest commit where the GitHub Actions succeeded" step finish successfully even if the `context.payload.pull_request` is undefined

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
           result-encoding: string
           # see https://stackoverflow.com/a/74868904
           script: |
-            async function fetchActionsSucceededSha1List(variables) {
+            async function fetchActionsSucceededSha1List({ workflowName, ...variables }) {
               // Use the GraphQL API instead of the REST API.
               // This allows us to save the rate limits of the REST API.
               // Instead, this step consumes the GraphQL API rate limit, but since few jobs use the GraphQL API, this is probably not a problem.
@@ -106,7 +106,7 @@ jobs:
                 result.repository.pullRequest.commits.nodes
                   .filter(pullRequestCommit =>
                     pullRequestCommit.commit.checkSuites.nodes.some(checkSuite =>
-                      checkSuite.workflowRun?.workflow.name === workflowNameOrFilepath
+                      checkSuite.workflowRun?.workflow.name === workflowName
                       && checkSuite.conclusion === 'SUCCESS'
                     )
                   )
@@ -122,23 +122,24 @@ jobs:
               );
             }
 
-            // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-            const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
             const baseSha1 = context.payload.pull_request?.base.sha;
             console.log('::group::baseSha1\n', baseSha1, '\n::endgroup::');
             if (!baseSha1) return '/';
 
+            // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+            const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
             const variables = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pullRequest: context.issue.number ?? Number(/^refs\/pull\/(\d+)(?:\/|$)/.exec(context.ref)?.[1]),
+              workflowName: workflowNameOrFilepath,
             };
             console.log('::group::variables\n', variables, '\n::endgroup::');
 
             const isFirstCommit = !context.payload.before;
             const actionsSucceededSha1List = isFirstCommit || !Number.isInteger(variables.pullRequest)
               ? null
-              : await fetchActionsSucceededSha1List(query, variables);
+              : await fetchActionsSucceededSha1List(variables);
             console.log('::group::actionsSucceededSha1List\n', actionsSucceededSha1List, '\n::endgroup::');
 
             try {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,30 +71,26 @@ jobs:
           result-encoding: string
           # see https://stackoverflow.com/a/74868904
           script: |
-            // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-            const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
-            const baseSha1 = context.payload.pull_request?.base.sha;
-            console.log('::group::baseSha1\n', baseSha1, '\n::endgroup::');
-            if (!baseSha1) return '/';
-
-            // Use the GraphQL API instead of the REST API.
-            // This allows us to save the rate limits of the REST API.
-            // Instead, this step consumes the GraphQL API rate limit, but since few jobs use the GraphQL API, this is probably not a problem.
-            const query = `query($owner: String!, $repo: String!, $pullRequest: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $pullRequest) {
-                  commits(last: 250) {
-                    nodes {
-                      url
-                      commit {
-                        oid
-                        authoredDate
-                        committedDate
-                        checkSuites(first: 100) {
-                          nodes {
-                            conclusion
-                            workflowRun {
-                              workflow { name }
+            async function fetchActionsSucceededSha1List(variables) {
+              // Use the GraphQL API instead of the REST API.
+              // This allows us to save the rate limits of the REST API.
+              // Instead, this step consumes the GraphQL API rate limit, but since few jobs use the GraphQL API, this is probably not a problem.
+              const query = `query($owner: String!, $repo: String!, $pullRequest: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pullRequest) {
+                    commits(last: 250) {
+                      nodes {
+                        url
+                        commit {
+                          oid
+                          authoredDate
+                          committedDate
+                          checkSuites(first: 100) {
+                            nodes {
+                              conclusion
+                              workflowRun {
+                                workflow { name }
+                              }
                             }
                           }
                         }
@@ -102,8 +98,36 @@ jobs:
                     }
                   }
                 }
-              }
-            }`;
+              }`;
+              const result = await github.graphql(query, variables);
+              console.log(`::group::fetch result\n${JSON.stringify(result, null, 2)}\n::endgroup::`);
+
+              return (
+                result.repository.pullRequest.commits.nodes
+                  .filter(pullRequestCommit =>
+                    pullRequestCommit.commit.checkSuites.nodes.some(checkSuite =>
+                      checkSuite.workflowRun?.workflow.name === workflowNameOrFilepath
+                      && checkSuite.conclusion === 'SUCCESS'
+                    )
+                  )
+                  .map(pullRequestCommit => ({
+                    sha1: pullRequestCommit.commit.oid,
+                    date: Math.max(
+                      new Date(pullRequestCommit.commit.authoredDate).getTime(),
+                      new Date(pullRequestCommit.commit.committedDate).getTime(),
+                    ),
+                  }))
+                  .sort((a, b) => b.date - a.date)
+                  .map(({ sha1 }) => sha1)
+              );
+            }
+
+            // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+            const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
+            const baseSha1 = context.payload.pull_request?.base.sha;
+            console.log('::group::baseSha1\n', baseSha1, '\n::endgroup::');
+            if (!baseSha1) return '/';
+
             const variables = {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -112,27 +136,9 @@ jobs:
             console.log('::group::variables\n', variables, '\n::endgroup::');
 
             const isFirstCommit = !context.payload.before;
-            const result = isFirstCommit || !Number.isInteger(variables.pullRequest)
+            const actionsSucceededSha1List = isFirstCommit || !Number.isInteger(variables.pullRequest)
               ? null
-              : await github.graphql(query, variables);
-            console.log(`::group::result\n${JSON.stringify(result, null, 2)}\n::endgroup::`);
-
-            const actionsSucceededSha1List = result?.repository.pullRequest.commits.nodes
-              .filter(pullRequestCommit =>
-                pullRequestCommit.commit.checkSuites.nodes.some(checkSuite =>
-                  checkSuite.workflowRun?.workflow.name === workflowNameOrFilepath
-                  && checkSuite.conclusion === 'SUCCESS'
-                )
-              )
-              .map(pullRequestCommit => ({
-                sha1: pullRequestCommit.commit.oid,
-                date: Math.max(
-                  new Date(pullRequestCommit.commit.authoredDate).getTime(),
-                  new Date(pullRequestCommit.commit.committedDate).getTime(),
-                ),
-              }))
-              .sort((a, b) => b.date - a.date)
-              .map(({ sha1 }) => sha1);
+              : await fetchActionsSucceededSha1List(query, variables);
             console.log('::group::actionsSucceededSha1List\n', actionsSucceededSha1List, '\n::endgroup::');
 
             try {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,9 @@ jobs:
           script: |
             // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
             const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
-            const baseSha1 = context.payload.pull_request.base.sha;
+            const baseSha1 = context.payload.pull_request?.base.sha;
             console.log('::group::baseSha1\n', baseSha1, '\n::endgroup::');
+            if (!baseSha1) return '/';
 
             // Use the GraphQL API instead of the REST API.
             // This allows us to save the rate limits of the REST API.
@@ -227,9 +228,9 @@ jobs:
                 delimiter = f"ghadelimiter_{hex(random.getrandbits(255))}"
               f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
-          diff_files = os.environ.get('LATEST_COMMIT_DIFF')
-          ignore_files = os.environ.get('IGNORE_FILES')
-          if 0 < len(str_to_set(diff_files) - str_to_set(ignore_files) - {''}):
+          diff_files = str_to_set(os.environ.get('LATEST_COMMIT_DIFF'))
+          ignore_files = str_to_set(os.environ.get('IGNORE_FILES'))
+          if ('/' in diff_files) or (0 < len(diff_files - ignore_files - {''})):
             export_var('run-test', '1')
 
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
           result-encoding: string
           # see https://stackoverflow.com/a/74868904
           script: |
+            const { inspect } = require('util');
+
             async function fetchActionsSucceededSha1List({ workflowName, ...variables }) {
               // Use the GraphQL API instead of the REST API.
               // This allows us to save the rate limits of the REST API.
@@ -122,34 +124,40 @@ jobs:
               );
             }
 
-            const baseSha1 = context.payload.pull_request?.base.sha;
-            console.log('::group::baseSha1\n', baseSha1, '\n::endgroup::');
-            if (!baseSha1) return '/';
-
-            // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-            const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
-            const variables = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pullRequest: context.issue.number ?? Number(/^refs\/pull\/(\d+)(?:\/|$)/.exec(context.ref)?.[1]),
-              workflowName: workflowNameOrFilepath,
-            };
-            console.log('::group::variables\n', variables, '\n::endgroup::');
-
-            const isFirstCommit = !context.payload.before;
-            const actionsSucceededSha1List = isFirstCommit || !Number.isInteger(variables.pullRequest)
-              ? null
-              : await fetchActionsSucceededSha1List(variables);
-            console.log('::group::actionsSucceededSha1List\n', actionsSucceededSha1List, '\n::endgroup::');
-
             try {
-              console.log('::group::Get file differences');
-              const latestSha1 = actionsSucceededSha1List?.[0] ?? baseSha1;
-              await exec.exec('git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin', [latestSha1]);
-              const { stdout: diffResult } = await exec.getExecOutput('git diff --name-only', [latestSha1]);
-              return diffResult;
-            } finally {
-              console.log('::endgroup::');
+              const baseSha1 = context.payload.pull_request?.base.sha;
+              console.log('::group::baseSha1\n', baseSha1, '\n::endgroup::');
+              if (!baseSha1) return '/';
+
+              // see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+              const workflowNameOrFilepath = process.env.GITHUB_WORKFLOW ?? context.workflow;
+              const variables = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pullRequest: context.issue.number ?? Number(/^refs\/pull\/(\d+)(?:\/|$)/.exec(context.ref)?.[1]),
+                workflowName: workflowNameOrFilepath,
+              };
+              console.log('::group::variables\n', variables, '\n::endgroup::');
+
+              const isFirstCommit = !context.payload.before;
+              const actionsSucceededSha1List = isFirstCommit || !Number.isInteger(variables.pullRequest)
+                ? null
+                : await fetchActionsSucceededSha1List(variables);
+              console.log('::group::actionsSucceededSha1List\n', actionsSucceededSha1List, '\n::endgroup::');
+
+              try {
+                console.log('::group::Get file differences');
+                const latestSha1 = actionsSucceededSha1List?.[0] ?? baseSha1;
+                await exec.exec('git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin', [latestSha1]);
+                const { stdout: diffResult } = await exec.getExecOutput('git diff --name-only', [latestSha1]);
+                return diffResult;
+              } finally {
+                console.log('::endgroup::');
+              }
+            } catch (error) {
+              core.error(inspect(error));
+              console.log(`::group::context\n${JSON.stringify({ ...context, issue: context.issue, repo: context.repo }, null, 2)}\n::endgroup::`);
+              return '/';
             }
 
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ Because it is the minimum version available for Vitest.
 * [#222] - Strictly check if the package manager has been disabled by Corepack
 * [#216] - Migrate from npm to pnpm
 * [#225] - Run CI only if differences exist
+* [#226] - Ensure that scripts in the "Get the diff from the latest commit where the GitHub Actions succeeded" step finish successfully even if the `context.payload.pull_request` is undefined
 
 [#182]: https://github.com/sounisi5011/package-version-git-tag/pull/182
 [#183]: https://github.com/sounisi5011/package-version-git-tag/pull/183
@@ -212,6 +213,7 @@ Because it is the minimum version available for Vitest.
 [#216]: https://github.com/sounisi5011/package-version-git-tag/pull/216
 [#224]: https://github.com/sounisi5011/package-version-git-tag/pull/224
 [#225]: https://github.com/sounisi5011/package-version-git-tag/pull/225
+[#226]: https://github.com/sounisi5011/package-version-git-tag/pull/226
 
 ## [3.0.0] (2020-06-02 UTC)
 


### PR DESCRIPTION
The `context.payload.pull_request` argument is not defined for CI invoked by events other than ["pull_request"](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request).